### PR TITLE
Edit PDRE2 on R.md

### DIFF
--- a/docs/software/R.md
+++ b/docs/software/R.md
@@ -14,9 +14,9 @@ mkdir -p ~/local/src
 cd ~/local/src
 
 # Install PCRE2 (Perl-compatible regular expression library)
-wget https://ftp.pcre.org/pub/pcre/pcre2-10.36.tar.gz
-tar zxvf pcre2-10.36.tar.gz
-cd pcre2-10.36
+wget https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.39/pcre2-10.39.tar.gz
+tar zxvf pcre2-10.39.tar.gz
+cd pcre2-10.39
 ./configure --prefix=$HOME/local
 make
 make install


### PR DESCRIPTION
下記について、ftp.pcre.orgが利用できない状態となっており(https://pcre.org)、https://github.com/PhilipHazel/pcre2/releases
からダウンロードするように変わりました。記事の内容を修正いたしました。

＞ https://ftp.pcre.org/pub/pcre/pcre2-10.36.tar.gz
＞のURL変わったか、version 2-10.36ってのが無
＞なって別のバージョンになったか、
＞ではないかと思うので確認してもらえますか？

下記に修正いたしました。
wget https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.39/pcre2-10.39.tar.gz
tar zxvf pcre2-10.39.tar.gz
cd pcre2-10.39
./configure --prefix=$HOME/local
make
make install
cd ~/local/src
