### PR TITLE
Edit ga_usage_JP_EN

### DIFF
--- a/docs/general_analysis_division/ga_usage.md
+++ b/docs/general_analysis_division/ga_usage.md
@@ -13,7 +13,7 @@ title: 使用方法（一般解析区画）
 
 長時間かかる計算、CPUやメモリを大規模に使う計算は、`qsub`コマンドにより計算ノード(compute node)上のバッチジョブ、並列ジョブ、アレイジョブとして実行してください。
 
-- ジョブスケジューラ Univa Grid Engine (UGE)の使い方については[システム構成 > ソフトウェア > Univa Grid Engine](../software/univa_grid_engine.md)をご参照ください。
+- ジョブスケジューラ Grid Engineの使い方については[システム構成 > ソフトウェア > Grid Engine](../software/grid_engine)をご参照ください。
 - 遺伝研スパコンで用意されているUGEキューについては[概要（一般解析区画) > UGEキューの種類](../general_analysis_division/ga_introduction.md)をご参照ください。
 - その他、利用可能なソフトウェアについては[システム構成>ソフトウェア](../software/software.md)をご参照ください。
 - 具体的な解析方法などについては[活用方法](../advanced_guides/advanced_guide.md)をご参照ください。

--- a/i18n/en/docusaurus-plugin-content-docs/current/general_analysis_division/ga_usage.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/general_analysis_division/ga_usage.md
@@ -13,7 +13,7 @@ For calculations that take a long time or use a large CPU or memory, run them as
 
 ### Reference
 
-- [System Configuration > Software > Univa Grid Engine](../software/univa_grid_engine.md) : how to use the job scheduler Univa Grid Engine (UGE)
+- [System Configuration > Software > Grid Engine](../software/grid_engine) : how to use the job scheduler Grid Engine
 - [Overview (A General Analysis Section) > Types of UGE Queues](../general_analysis_division/ga_introduction.md) : the UGE queues available on the NIG supercomputer
 - [System Configuration > Software](../software/software.md) : other available softwares
 - [Advanced guide](../advanced_guides/advanced_guide.md) : specific analysis methods


### PR DESCRIPTION
一般解析区画の「使用方法(一般解析区画)」のページ(日/英)で、以下の内容を修正いたしました。

・"Univa Grid Engine"　=> "Grid Engine" に修正
・リンク先を修正　"Univa Grid Engine"のページ => 正しいページ "Grid Engine"

よろしくお願いいたします。
