### PR TITLE
Edit legislation.md

### DIFF
--- a/docs/application/legislation.md
+++ b/docs/application/legislation.md
@@ -35,4 +35,4 @@ title: "関連法規等"
 
 - [医療情報システムの安全管理に関するガイドライン　第5.1版（令和3年1月）](https://www.mhlw.go.jp/stf/shingi/0000516275.html)
 - [医療情報を取り扱う情報システム・サービスの提供事業者における安全管理ガイドライン](https://www.meti.go.jp/policy/mono_info_service/healthcare/teikyoujigyousyagl.html)
-- [政府機関等の情報セキュリティ対策のための統一基準群（令和3年度版）](https://www.nisc.go.jp/active/general/kijunr3.html)
+- [政府機関等の情報セキュリティ対策のための統一基準群（令和3年度版）](https://www.nisc.go.jp/policy/group/general/kijun.html)

--- a/i18n/en/docusaurus-plugin-content-docs/current/application/legislation.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/application/legislation.md
@@ -35,4 +35,4 @@ The personal genomic analysis section in the NIG supercomputer complies with the
 
 - [Guideline for the Security Management of Medical Information Systems version 5.1 (Jan, 2021)](https://www.mhlw.go.jp/stf/shingi/0000516275.html)
 - [Guidelines for Safety Management of Medical Information by Providers of Information Systems and Services Handling Medical Information](https://www.meti.go.jp/policy/mono_info_service/healthcare/teikyoujigyousyagl.html)
-- [Common Standards for Cybersecurity Measures for Government Agencies and Related Agencies（FY2021）](https://www.nisc.go.jp/eng/pdf/kijyunr3-en.pdf)
+- [Common Standards for Cybersecurity Measures for Government Agencies and Related Agencies（FY2021）](https://www.nisc.go.jp/eng/index.html)


### PR DESCRIPTION
「政府機関等のサイバーセキュリティ対策のための統一基準群」のリンクが切れていたため、リンクの指し先を修正いたしました。
どうぞよろしくお願いいたします。