### PR TITLE
Edit change application URL

### DIFF
--- a/docs/application/registration.md
+++ b/docs/application/registration.md
@@ -34,12 +34,12 @@ title: "ユーザ登録・変更申請"
 </table>
 
 <ul>
-<li><a href="https://sc-account.ddbj.nig.ac.jp/application/registration">ユーザ登録内容変更申請</a>
+<li><a href="https://sc-account.ddbj.nig.ac.jp/auth/realms/master/protocol/openid-connect/auth?client_id=sc&scope=openid&response_type=code&redirect_uri=https%3A%2F%2Fsc-account.ddbj.nig.ac.jp%2Fapi%2Fauth%2Fcallback%2Fkeycloak&state=6ygcuJParJ3i8ZlDMnKicXvW3MxkWp4t06IBKOVAbIE&code_challenge=hDLDfyOsqUc58Z-xzzz1g5ybLDycWgY7UV8e-qu1jd8&code_challenge_method=S256">ユーザ登録内容変更申請</a>
   <ul>
   <li>所属などが変更になった場合は速やかに変更内容の登録をお願いいたします。</li>
   </ul>
 </li>
-<li><a href="https://sc-account.ddbj.nig.ac.jp/application/registration">パスワード変更申請</a>
+<li><a href="https://sc-account.ddbj.nig.ac.jp/auth/realms/master/protocol/openid-connect/auth?client_id=sc&scope=openid&response_type=code&redirect_uri=https%3A%2F%2Fsc-account.ddbj.nig.ac.jp%2Fapi%2Fauth%2Fcallback%2Fkeycloak&state=6ygcuJParJ3i8ZlDMnKicXvW3MxkWp4t06IBKOVAbIE&code_challenge=hDLDfyOsqUc58Z-xzzz1g5ybLDycWgY7UV8e-qu1jd8&code_challenge_method=S256">パスワード変更申請</a>
   <ul>
   <li>パスワードの変更はこちらからお願いします。</li>
   <li>変更手順は<a href="https://sc.ddbj.nig.ac.jp/application/change_loginpwd">ログインパスワード変更申請方法</a>をご参照ください。</li>

--- a/docs/application/renewal.md
+++ b/docs/application/renewal.md
@@ -4,7 +4,7 @@ title: "年度末アカウント継続申請"
 ---
 
 
-- [ログインアカウント年度末更新・停止申請](https://sc-account.ddbj.nig.ac.jp/application/registration) 
+- [ログインアカウント年度末更新・停止申請](https://sc-account.ddbj.nig.ac.jp/auth/realms/master/protocol/openid-connect/auth?client_id=sc&scope=openid&response_type=code&redirect_uri=https%3A%2F%2Fsc-account.ddbj.nig.ac.jp%2Fapi%2Fauth%2Fcallback%2Fkeycloak&state=6ygcuJParJ3i8ZlDMnKicXvW3MxkWp4t06IBKOVAbIE&code_challenge=hDLDfyOsqUc58Z-xzzz1g5ybLDycWgY7UV8e-qu1jd8&code_challenge_method=S256) 
     - 年度末のログインアカウントの更新手続きと成果報告はこちらからお願いします。
 
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/application/registration.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/application/registration.md
@@ -33,12 +33,12 @@ New user registration application screen
 </table>
 
 <ul>
-<li><a href="https://sc-account.ddbj.nig.ac.jp/en/application/registration">Request to change user registration details</a>
+<li><a href="https://sc-account.ddbj.nig.ac.jp/auth/realms/master/protocol/openid-connect/auth?client_id=sc&scope=openid&response_type=code&redirect_uri=https%3A%2F%2Fsc-account.ddbj.nig.ac.jp%2Fapi%2Fauth%2Fcallback%2Fkeycloak&state=6ygcuJParJ3i8ZlDMnKicXvW3MxkWp4t06IBKOVAbIE&code_challenge=hDLDfyOsqUc58Z-xzzz1g5ybLDycWgY7UV8e-qu1jd8&code_challenge_method=S256">Request to change user registration details</a>
   <ul>
   <li>When your affiliation and othes changes, register it as soon as possible.</li>
   </ul>
 </li>
-<li><a href="https://sc-account.ddbj.nig.ac.jp/en/application/registration">Password change application</a>
+<li><a href="https://sc-account.ddbj.nig.ac.jp/auth/realms/master/protocol/openid-connect/auth?client_id=sc&scope=openid&response_type=code&redirect_uri=https%3A%2F%2Fsc-account.ddbj.nig.ac.jp%2Fapi%2Fauth%2Fcallback%2Fkeycloak&state=6ygcuJParJ3i8ZlDMnKicXvW3MxkWp4t06IBKOVAbIE&code_challenge=hDLDfyOsqUc58Z-xzzz1g5ybLDycWgY7UV8e-qu1jd8&code_challenge_method=S256">Password change application</a>
   <ul>
   <li>change your password here.</li>
   <li>For the change procedure, refer to <a href="https://sc.ddbj.nig.ac.jp/en/application/change_loginpwd">How to apply for login password change</a>.</li>

--- a/i18n/en/docusaurus-plugin-content-docs/current/application/renewal.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/application/renewal.md
@@ -4,7 +4,7 @@ title: "Applying for a renewal of your login-account of the end of the fiscal ye
 ---
 
 
-- [Applying for a renewal of your login-account or stopping of the end of the fiscal year](https://sc-account.ddbj.nig.ac.jp/application/registration) 
+- [Applying for a renewal of your login-account or stopping of the end of the fiscal year](https://sc-account.ddbj.nig.ac.jp/auth/realms/master/protocol/openid-connect/auth?client_id=sc&scope=openid&response_type=code&redirect_uri=https%3A%2F%2Fsc-account.ddbj.nig.ac.jp%2Fapi%2Fauth%2Fcallback%2Fkeycloak&state=6ygcuJParJ3i8ZlDMnKicXvW3MxkWp4t06IBKOVAbIE&code_challenge=hDLDfyOsqUc58Z-xzzz1g5ybLDycWgY7UV8e-qu1jd8&code_challenge_method=S256) 
     - Here is applying for a renewal of your login-account of the end of the fiscal year and reporting your results
 
 


### PR DESCRIPTION
以下、滝口さんより、利用申請内容変更のURLを変更してほしいとのご要望がございました。
URLを修正いたしました。
どうぞよろしくお願いいたします。

〔ご要望内容〕
利用申請登録の登録内容を変更するとき、「[ユーザ登録内容変更申請](https://sc-account.ddbj.nig.ac.jp/application/registration)」「[パスワード変更申請](https://sc-account.ddbj.nig.ac.jp/application/registration)」「[ログインアカウント年度末更新・停止申請](https://sc-account.ddbj.nig.ac.jp/application/registration)」をクリックすると、以下の画面が表示されるため、新規登録申請をしてくる方がいる。この画面が表示されたときに、どこからログインしていいのかわからないため、ここに飛ぶのではなく、直接ログイン画面に飛ぶように、URLを変更してほしい。


![Screenshot at 2022-07-26 16-47-36](https://user-images.githubusercontent.com/56281391/180952404-f0653800-b40e-424d-8a86-8ea527260874.png)


〔修正箇所〕
URLを修正した。
https://sc-account.ddbj.nig.ac.jp/application/registration 
=> https://sc-account.ddbj.nig.ac.jp/auth/realms/master/protocol/openid-connect/auth?client_id=sc&scope=openid&response_type=code&redirect_uri=https%3A%2F%2Fsc-account.ddbj.nig.ac.jp%2Fapi%2Fauth%2Fcallback%2Fkeycloak&state=29wDp4DkAlZQj2MXuiWx1juVw0yMM37xzEJyfLY9w-M&code_challenge=xtU1VDH-HLyuOd_pv0tbp1x0FHNOFqEa75w0e05yM1E&code_challenge_method=S256　に変更

![Screenshot at 2022-07-26 16-51-44](https://user-images.githubusercontent.com/56281391/180953134-05bf9d36-9b80-4b85-997e-2b13ae9a235f.png)

