### PR TITLE
申請内容の変更のURLの変更

### DIFF
--- a/docs/application/registration.md
+++ b/docs/application/registration.md
@@ -30,7 +30,7 @@ title: "利用申請・変更"
 
 - メールアドレスは誤送信対策のためフリーメールではなく所属機関のメールアドレスを記載してください。
 - 利用目的は正確に記載してください。ここで記載した利用目的以外でのスパコンの利用は禁止しています。
-    
+
 
 
 </td>
@@ -107,7 +107,7 @@ title: "利用申請・変更"
 ## 申請内容の変更
 
 
-所属などが変更になった場合は速やかに[こちらのページから申請内容の変更](https://sc-account.ddbj.nig.ac.jp/auth/realms/master/protocol/openid-connect/auth?client_id=sc&scope=openid&response_type=code&redirect_uri=https%3A%2F%2Fsc-account.ddbj.nig.ac.jp%2Fapi%2Fauth%2Fcallback%2Fkeycloak&state=6ygcuJParJ3i8ZlDMnKicXvW3MxkWp4t06IBKOVAbIE&code_challenge=hDLDfyOsqUc58Z-xzzz1g5ybLDycWgY7UV8e-qu1jd8&code_challenge_method=S256)をお願いいたします。
+所属などが変更になった場合は速やかに[こちらのページから申請内容の変更](https://sc-account.ddbj.nig.ac.jp/login)をお願いいたします。
 
 
 申請内容の変更ページにアクセスすると、最初にページへのログイン画面が表示されます。
@@ -118,5 +118,3 @@ title: "利用申請・変更"
 申請内容の変更ページから、所属、SSH 公開鍵、パスワードなどの変更やアカウントの利用終了の申請などができます。
 
 ![](Change_App_JP.png)
-
-


### PR DESCRIPTION
申請内容を変更するためにアクセスするURLを変更しました。

元のURLだと認証サービスのURLやパラメータの構造が変更されるたびにURLを変更する必要があるので、その影響を受けないURLに変更しています。

本来は認証後に各申請のURLにコールバックするようにしたほうがユーザにとって優しいとは思うのですが、現段階では未実装です。