### PR TITLE
Edit paper2021

### DIFF
--- a/docs/report/papers_2012.md
+++ b/docs/report/papers_2012.md
@@ -1,15 +1,17 @@
 ---
 id: papers_2012
-title: 論文リスト(2012)
+title: 論文のリスト(2012)
 ---
 
-2012.01.01 -- 2012.12.31にユーザによって発表された論文リスト
+## 2012.01.01 -- 2012.12.31にユーザによって発表された論文のリスト
+
+### 2012年度の年度末更新時に集計した論文
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/docs/report/papers_2013.md
+++ b/docs/report/papers_2013.md
@@ -1,15 +1,17 @@
 ---
 id: papers_2013
-title: 論文リスト(2013)
+title: 論文のリスト(2013)
 ---
 
-2013.01.01 -- 2013.12.31にユーザによって発表された論文リスト
+## 2013.01.01 -- 2013.12.31にユーザによって発表された論文のリスト
+
+### 2013年度の年度末更新時に集計した論文
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/docs/report/papers_2014.md
+++ b/docs/report/papers_2014.md
@@ -1,15 +1,18 @@
 ---
 id: papers_2014
-title: 論文リスト(2014)
+title: 論文のリスト(2014)
 ---
 
-2014.01.01 -- 2014.12.31にユーザによって発表された論文リスト
+## 2014.01.01 -- 2014.12.31にユーザによって発表された論文のリスト
+
+### 2014年度の年度末更新時に集計した論文
+
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/docs/report/papers_2015.md
+++ b/docs/report/papers_2015.md
@@ -1,15 +1,18 @@
 ---
 id: papers_2015
-title: 論文リスト(2015)
+title: 論文のリスト(2015)
 ---
 
-2015.01.01 -- 2015.12.31にユーザによって発表された論文リスト
+## 2015.01.01 -- 2015.12.31にユーザによって発表された論文のリスト
+
+### 2015年度の年度末更新時に集計した論文
+
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/docs/report/papers_2016.md
+++ b/docs/report/papers_2016.md
@@ -1,15 +1,18 @@
 ---
 id: papers_2016
-title: 論文リスト(2016)
+title: 論文のリスト(2016)
 ---
 
-2016.01.01 -- 2016.12.31にユーザによって発表された論文リスト
+## 2016.01.01 -- 2016.12.31にユーザによって発表された論文のリスト
+
+### 2016年度の年度末更新時に集計した論文
+
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/docs/report/papers_2017.md
+++ b/docs/report/papers_2017.md
@@ -1,15 +1,18 @@
 ---
 id: papers_2017
-title: 論文リスト(2017)
+title: 論文のリスト(2017)
 ---
 
-2017.01.01 -- 2017.12.31にユーザによって発表された論文リスト
+## 2017.01.01 -- 2017.12.31にユーザによって発表された論文のリスト
+
+### 2017年度の年度末更新時に集計した論文
+
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/docs/report/papers_2018.md
+++ b/docs/report/papers_2018.md
@@ -1,15 +1,18 @@
 ---
 id: papers_2018
-title: 論文リスト(2018)
+title: 論文のリスト(2018)
 ---
 
-2018.01.01. -- 2018.12.31にユーザによって発表された論文リスト
+## 2018.01.01. -- 2018.12.31にユーザによって発表された論文のリスト
+
+### 2018年度の年度末更新時に集計した論文
+
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/docs/report/papers_2019.md
+++ b/docs/report/papers_2019.md
@@ -1,16 +1,17 @@
 ---
 id: papers_2019
-title: 論文リスト(2019)
+title: 論文のリスト(2019)
 ---
 
-2019.01.01 -- 2019.12.31にユーザによって発表された論文リスト
+## 2019.01.01 -- 2019.12.31にユーザによって発表された論文のリスト
 
+### 2019年度の年度末更新時に集計した論文
 
 <table>
 <tr>
     <td></td>
-    <td width="150">Authors (Japanese)</td>
-    <td>Authors</td>
+    <td width="150">Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>
@@ -954,5 +955,29 @@ ted with Lotus japonicus in Natural Environments</td>
 	<td>Cell Reports Volume 26, Issue 9, 26 February 2019, Pages 2274-2281.e5</td>
 	<td>NULL</td>
 	<td>doi.org/10.1016/j.celrep.2019.01.109</td>
+</tr>
+</table>
+
+
+### 2019年度の年度末更新時の後に追加で申請があった論文
+
+<table>
+<tr>
+    <td></td>
+    <td width="150">Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
+    <td>Title</td>
+    <td>Journal, Volume, Number, Pages</td>
+    <td>PMID</td>
+    <td>DOI</td>
+</tr>
+<tr>
+    <td>1</td>
+    <td>Yassouf Mhd Yousuf</td>
+    <td>M Yousuf Yassouf</td>
+    <td>Compliance with Deferoxamine Therapy and Thyroid Dysfunction of Patients with β-Thalassemia Major in Syria</td>
+    <td>Hemoglobin. 2019 May;43(3):218-221.</td>
+    <td>31373517</td>
+    <td>doi: 10.1080/03630269.2019.1639517</td>
 </tr>
 </table>

--- a/docs/report/papers_2020.md
+++ b/docs/report/papers_2020.md
@@ -1,15 +1,17 @@
 ---
 id: papers_2020
-title: 論文リスト(2020)
+title: 論文のリスト(2020)
 ---
 
-2020.01.01 -- 2020.12.31にユーザによって発表された論文リスト
+## 2020.01.01 -- 2020.12.31にユーザによって発表された論文のリスト
+
+### 2020年度の年度末更新時に集計した論文
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>
@@ -1133,5 +1135,30 @@ e in Japanese gentian with the CRISPR/Cas9 system</td>
 	<td>Insect Sci. 2020 Apr;27(2):202-211.</td>
 	<td>30203565</td>
 	<td>doi: 10.1111/1744-7917.12640.</td>
+</tr>
+</table>
+
+### 2020年度の年度末更新時の後に追加で申請があった論文
+
+<table>
+<tr>
+    <td></td>
+    <td>Supercomputer users in authors list(Japanese)</td>
+    <td>Supercomputer users in authors list</td>
+    <td>Title</td>
+    <td>Journal, Volume, Number, Pages</td>
+    <td>PMID</td>
+    <td>DOI</td>
+    <td>
+</td>
+</tr>
+<tr>
+    <td>1</td>
+    <td>鈴木 郁夫</td>
+    <td>Ikuo K Suzuki</td>
+    <td>Molecular drivers of human cerebral cortical evolution</td>
+    <td>Neuroscience research. 2020 Feb;151:1-14.</td>
+    <td>31175883</td>
+    <td>doi: 10.1016/j.neures.2019.05.007</td>
 </tr>
 </table>

--- a/docs/report/papers_2021.md
+++ b/docs/report/papers_2021.md
@@ -1,0 +1,1691 @@
+---
+id: papers_2021
+title: 論文のリスト(2021)
+---
+
+## 2021.01.01 -- 2021.12.31にユーザによって発表された論文のリスト
+
+### 2021年度の年度末更新時に集計した論文
+
+
+<table>
+<tr>
+    <td></td>
+    <td>Supercomputer users in authors list(Japanese)</td>
+    <td>Supercomputer users in authors list</td>
+    <td>Title</td>
+    <td>Journal, Volume, Number, Pages</td>
+    <td>PMID</td>
+    <td>DOI
+</td>
+</tr>
+<tr>
+    <td>1</td>
+    <td>石橋 知彦</td>
+    <td>Tomohiko Ishibashi</td>
+    <td>Aryl hydrocarbon receptor is essential for the pathogenesis of pulmonary arterial hypertension</td>
+    <td>Proc Natl Acad Sci U S A. 2021 Mar 16;118(11):e2023899118.</td>
+    <td>33836606</td>
+    <td>doi: 10.1073/pnas.2023899118.
+</td>
+</tr>
+<tr>
+    <td>2</td>
+    <td>平瀬 祥太朗, 岩崎 渉</td>
+    <td>Shotaro Hirase, Wataru Iwasaki</td>
+    <td>Integrative genomic phylogeography reveals signs of mitonuclear incompatibility in a natural hybrid goby population</td>
+    <td>Evolution. 2021 Jan;75(1):176-194.</td>
+    <td>33165944</td>
+    <td>doi: 10.1111/evo.14120. 
+</td>
+</tr>
+<tr>
+    <td>3</td>
+    <td>Ravinet Mark, 石川 麻乃</td>
+    <td>Mark Ravinet,Asano Ishikawa</td>
+    <td>Patterns of genomic divergence and introgression between Japanese sticklebackspecies with overlapping breeding habitats.</td>
+    <td>J Evol Biol. 2021 Jan;34(1):114-127. </td>
+    <td>32557887</td>
+    <td>doi: 10.1111/jeb.13664.
+</td>
+</tr>
+<tr>
+    <td>4</td>
+    <td>西原 昌宏</td>
+    <td>Masahiro Nishihara</td>
+    <td>Identification and characterization of xanthone biosynthetic genes contributing to the vivid red coloration of red-flowered gentian</td>
+    <td>The Plant journal : for cell and molecular biology. 2021 Sep;107(6):1711-1723.</td>
+    <td>34245606</td>
+    <td>doi: 10.1111/tpj.15412
+</td>
+</tr>
+<tr>
+    <td>5</td>
+    <td>齋藤 裕</td>
+    <td>Yutaka Saito</td>
+    <td>Evotuning protocols for Transformer-based variant effect prediction on multi-domain proteins</td>
+    <td>Briefings in bioinformatics. 2021 Nov 5;22(6):bbab234.</td>
+    <td>34180966</td>
+    <td>doi: 10.1093/bib/bbab234
+</td>
+</tr>
+<tr>
+    <td>6</td>
+    <td>江副 晃洋</td>
+    <td>Akihiro Ezoe</td>
+    <td>Degree of Functional Divergence in Duplicates Is Associated with Distinct Roles in Plant Evolution</td>
+    <td>Molecular biology and evolution. 2021 Apr 13;38(4):1447-1459.</td>
+    <td>33290522</td>
+    <td>doi: 10.1093/molbev/msaa302
+</td>
+</tr>
+<tr>
+    <td>7</td>
+    <td>安井 康夫</td>
+    <td>Yasuo Yasui</td>
+    <td>Targeted amplicon sequencing + next-generation sequencing–based bulked segregant analysis identified genetic loci associated with preharvest sprouting tolerance in common buckwheat (Fagopyrum esculentum)</td>
+    <td>BMC plant biology. 2021 Jan 6;21(1):18.</td>
+    <td>33407135</td>
+    <td>doi: 10.1186/s12870-020-02790-w
+</td>
+</tr>
+<tr>
+    <td>8</td>
+    <td>鈴木 啓道</td>
+    <td>Hiromichi Suzuki</td>
+    <td>The transcriptional landscape of Shh medulloblastoma</td>
+    <td>Nature communications. 2021 Mar 19;12(1):1749.</td>
+    <td>33741928</td>
+    <td>doi: 10.1038/s41467-021-21883-0
+</td>
+</tr>
+<tr>
+    <td>9</td>
+    <td>鈴木 郁夫</td>
+    <td>Ikuo K Suzuki</td>
+    <td>1q21.1 distal copy number variants are associated with cerebral and cognitive alterations in humans</td>
+    <td>Translational psychiatry. 2021 Mar 22;11(1):182.</td>
+    <td>33753722</td>
+    <td>doi: 10.1038/s41398-021-01213-0
+</td>
+</tr>
+<tr>
+    <td>10</td>
+    <td>齋藤 裕</td>
+    <td>Yutaka Saito</td>
+    <td>Rational thermostabilisation of four-helix bundle dimeric de novo proteins</td>
+    <td>Scientific reports. 2021 Apr 6;11(1):7526.</td>
+    <td>33824364</td>
+    <td>doi: 10.1038/s41598-021-86952-2
+</td>
+</tr>
+<tr>
+    <td>11</td>
+    <td>齋藤 裕</td>
+    <td>Yutaka Saito</td>
+    <td>Comparative analysis of the relationship between translation efficiency and sequence features of endogenous proteins in multiple organisms</td>
+    <td>Genomics. 2021 Jul;113(4):2675-2682.</td>
+    <td>34058272</td>
+    <td>doi: 10.1016/j.ygeno.2021.05.037
+</td>
+</tr>
+<tr>
+    <td>12</td>
+    <td>山口 暢俊, 稲垣 宗一</td>
+    <td>Nobutoshi Yamaguchi, Soichi Inagaki</td>
+    <td>H3K27me3 demethylases alter HSP22 and HSP17.6C expression in response to recurring heat in Arabidopsis</td>
+    <td>Nature communications. 2021 Jun 9;12(1):3480.</td>
+    <td>34108473</td>
+    <td>doi: 10.1038/s41467-021-23766-w
+</td>
+</tr>
+<tr>
+    <td>13</td>
+    <td>村越 祐美, 高尾 祥丈</td>
+    <td>Yumi Murakoshi, Yoshitake Takao</td>
+    <td>Draft Genome Sequence of Sicyoidochytrium minutum DNA Virus Strain 001</td>
+    <td>Microbiology resource announcements. 2021 Jun 10;10(23):e0041821.</td>
+    <td>34110234</td>
+    <td>doi: 10.1128/MRA.00418-21
+</td>
+</tr>
+<tr>
+    <td>14</td>
+    <td>小野寺 康之</td>
+    <td>Yasuyuki Onodera </td>
+    <td>A spinach genome assembly with remarkable completeness, and its use for rapid identification of candidate genes for agronomic traits</td>
+    <td>DNA research : an international journal for rapid publication of reports on genes and genomes. 2021 Jun 25;28(3):dsab004.</td>
+    <td>34142133</td>
+    <td>doi: 10.1093/dnares/dsab004
+</td>
+</tr>
+<tr>
+    <td>15</td>
+    <td>宮原 平</td>
+    <td>Taira Miyahara</td>
+    <td>Effect of Transgenic Rootstock Grafting on the Omics Profiles in Tomato</td>
+    <td>Food safety (Tokyo, Japan). 2021 Jun 25;9(2):32-47.</td>
+    <td>34249588</td>
+    <td>doi: 10.14252/foodsafetyfscj.D-20-00032
+</td>
+</tr>
+<tr>
+    <td>16</td>
+    <td>齋藤 裕</td>
+    <td>Yutaka Saito</td>
+    <td>Machine learning approach for discrimination of genotypes based on bright-field cellular images</td>
+    <td>NPJ systems biology and applications. 2021 Jul 21;7(1):31.</td>
+    <td>34290253</td>
+    <td>doi: 10.1038/s41540-021-00190-w
+</td>
+</tr>
+<tr>
+    <td>17</td>
+    <td>瀬川 高弘</td>
+    <td>Takahiro Segawa</td>
+    <td>Spatial and Temporal Variations in Pigment and Species Compositions of Snow Algae on Mt. Tateyama in Toyama Prefecture, Japan</td>
+    <td>Frontiers in plant science. 2021 Jul 5;12:689119.</td>
+    <td>34290725</td>
+    <td>doi: 10.3389/fpls.2021.689119
+</td>
+</tr>
+<tr>
+    <td>18</td>
+    <td>平瀬 祥太朗</td>
+    <td>Shotaro Hirase</td>
+    <td>Genomic Evidence for Speciation with Gene Flow in Broadcast Spawning Marine Invertebrates</td>
+    <td>Molecular biology and evolution. 2021 Oct 27;38(11):4683-4699.</td>
+    <td>34311468</td>
+    <td>doi: 10.1093/molbev/msab194
+</td>
+</tr>
+<tr>
+    <td>19</td>
+    <td>松波 雅俊</td>
+    <td>Masatoshi Matsunami</td>
+    <td>Coevolution between MHC class I and Antigen Processing Genes in salamanders.</td>
+    <td>Molecular biology and evolution. 2021 Oct 27;38(11):5092-5106.</td>
+    <td>34375431</td>
+    <td>doi: 10.1093/molbev/msab237
+</td>
+</tr>
+<tr>
+    <td>20</td>
+    <td>高橋 鉄美</td>
+    <td>Tetsumi Takahashi</td>
+    <td>Mapping of quantitative trait loci underlying a magic trait in ongoing ecological speciation</td>
+    <td>BMC genomics. 2021 Aug 12;22(1):615.</td>
+    <td>34384356</td>
+    <td>doi: 10.1186/s12864-021-07908-4
+</td>
+</tr>
+<tr>
+    <td>21</td>
+    <td>瀬川 高弘, 西原 秀典</td>
+    <td>Takahiro Segawa, Hidenori Nishihara</td>
+    <td>Ancient DNA reveals multiple origins and migration waves of extinct Japanese brown bear lineages</td>
+    <td>Royal Society open science. 2021 Aug 4;8(8):210518.</td>
+    <td>34386259</td>
+    <td>doi: 10.1098/rsos.210518
+</td>
+</tr>
+<tr>
+    <td>22</td>
+    <td>川崎 純菜, 堀江 真行</td>
+    <td>Junna Kawasaki, Masayuki Horie</td>
+    <td>Hidden Viral Sequences in Public Sequencing Data and Warning for Future Emerging Diseases</td>
+    <td>mBio. 2021 Aug 31;12(4):e0163821.</td>
+    <td>34399612</td>
+    <td>doi: 10.1128/mBio.01638-21
+</td>
+</tr>
+<tr>
+    <td>23</td>
+    <td>草間 和哉</td>
+    <td>Kazuya Kusama </td>
+    <td>The effect of bta-miR-26b in intrauterine extracellular vesicles on maternal immune system during the implantation period</td>
+    <td>Biochemical and biophysical research communications. 2021 Oct 8;573:100-106.</td>
+    <td>34403805</td>
+    <td>doi: 10.1016/j.bbrc.2021.08.019
+</td>
+</tr>
+<tr>
+    <td>24</td>
+    <td>松前 ひろみ</td>
+    <td>Hiromi Matsumae</td>
+    <td>Exploring correlations in genetic and cultural variation across language families in Northeast Asia</td>
+    <td>Science advances. 2021 Aug 18;7(34):eabd9223.</td>
+    <td>34407936</td>
+    <td>doi: 10.1126/sciadv.abd9223
+</td>
+</tr>
+<tr>
+    <td>25</td>
+    <td>石川 麻乃</td>
+    <td>Asano Ishikawa</td>
+    <td>The effect of bta-miR-26b in intrauterine extracellular vesicles on maternal immune system during the implantation period</td>
+    <td>Biology letters. 2021 Aug;17(8):20210204.</td>
+    <td>34428959</td>
+    <td>doi: 10.1098/rsbl.2021.0204
+</td>
+</tr>
+<tr>
+    <td>26</td>
+    <td>湯山 育子</td>
+    <td>Ikuko Yuyama</td>
+    <td>Transcriptome Analysis of Durusdinium Associated with the Transition from Free-Living to Symbiotic</td>
+    <td>Microorganisms. 2021 Jul 22;9(8):1560.</td>
+    <td>34442639</td>
+    <td>doi: 10.3390/microorganisms9081560
+</td>
+</tr>
+<tr>
+    <td>27</td>
+    <td>前野 慎太朗, 谷澤 靖洋, 遠藤 明仁</td>
+    <td>Shintaro Maeno, Yasuhiro Tanizawa, Akihito Endo</td>
+    <td>Oligosaccharide Metabolism and Lipoteichoic Acid Production in Lactobacillus gasseri and Lactobacillus paragasseri</td>
+    <td>Microorganisms. 2021 Jul 26;9(8):1590.</td>
+    <td>34442669</td>
+    <td>doi: 10.3390/microorganisms9081590
+</td>
+</tr>
+<tr>
+    <td>28</td>
+    <td>門田 有希</td>
+    <td>Yuki Monden</td>
+    <td>Transcriptome Analysis Reveals Key Genes Involved in Weevil Resistance in the Hexaploid Sweetpotato</td>
+    <td>Plants (Basel, Switzerland). 2021 Jul 27;10(8):1535.</td>
+    <td>34451581</td>
+    <td>doi: 10.3390/plants10081535
+</td>
+</tr>
+<tr>
+    <td>29</td>
+    <td>向笠 勝貴</td>
+    <td>Katsuki Mukaigasa</td>
+    <td>The developmental hourglass model is applicable to the spinal cord based on single-cell transcriptomes and non-conserved cis-regulatory elements</td>
+    <td>Development, growth &amp; differentiation. 2021 Sep;63(7):372-391.</td>
+    <td>34473348</td>
+    <td>doi: 10.1111/dgd.12750
+</td>
+</tr>
+<tr>
+    <td>30</td>
+    <td>松井 求</td>
+    <td>Motomu Matsui</td>
+    <td>Machine learning-assisted single-cell Raman fingerprinting for in situ and nondestructive classification of prokaryotes</td>
+    <td>iScience. 2021 Aug 11;24(9):102975.</td>
+    <td>34485857</td>
+    <td>doi: 10.1016/j.isci.2021.102975
+</td>
+</tr>
+<tr>
+    <td>31</td>
+    <td>加藤 有己</td>
+    <td>Yuki Kato</td>
+    <td>Mutations in the adenosine deaminase ADAR1 that prevent endogenous Z-RNA editing induce Aicardi-Goutieres syndrome-like encephalopathy</td>
+    <td>Immunity. 2021 Sep 14;54(9):1976-1988.e7.</td>
+    <td>34525338</td>
+    <td>doi: 10.1016/j.immuni.2021.08.022
+</td>
+</tr>
+<tr>
+    <td>32</td>
+    <td>松波 雅俊</td>
+    <td>Masatoshi Matsunami </td>
+    <td>Species divergence and repeated ancient hybridization in a Sulawesian lake system</td>
+    <td>Journal of evolutionary biology. 2021 Nov;34(11):1767-1780.</td>
+    <td>34532915</td>
+    <td>doi: 10.1111/jeb.13932
+</td>
+</tr>
+<tr>
+    <td>33</td>
+    <td>井原 邦夫</td>
+    <td>Kunio Ihara</td>
+    <td>Identification of ksg1 mutation showing long-lived phenotype in fission yeast</td>
+    <td>Genes to cells : devoted to molecular &amp; cellular mechanisms. 2021 Dec;26(12):967-978.</td>
+    <td>34534388</td>
+    <td>doi: 10.1111/gtc.12897
+</td>
+</tr>
+<tr>
+    <td>34</td>
+    <td>一色 真理子</td>
+    <td>Mariko Isshiki</td>
+    <td>Admixture with indigenous people helps local adaptation: admixture-enabled selection in Polynesians</td>
+    <td>BMC ecology and evolution. 2021 Sep 22;21(1):179.</td>
+    <td>34551727</td>
+    <td>doi: 10.1186/s12862-021-01900-y
+</td>
+</tr>
+<tr>
+    <td>35</td>
+    <td>西原 秀典</td>
+    <td>Hidenori Nishihara</td>
+    <td>Replacement of owl monkey centromere satellite by a newly evolved variant was a recent and rapid process</td>
+    <td>Genes to cells : devoted to molecular &amp; cellular mechanisms. 2021 Dec;26(12):979-986.</td>
+    <td>34570411</td>
+    <td>doi: 10.1111/gtc.12898
+</td>
+</tr>
+<tr>
+    <td>36</td>
+    <td>草間 和哉, 吉田 佳乃子</td>
+    <td>Kazuya Kusama, Kanoko Yoshida</td>
+    <td>PGE2 and Thrombin Induce Myofibroblast Transdifferentiation via Activin A and CTGF in Endometrial Stromal Cells</td>
+    <td>Endocrinology. 2021 Dec 1;162(12):bqab207.</td>
+    <td>34606582</td>
+    <td>doi: 10.1210/endocr/bqab207
+</td>
+</tr>
+<tr>
+    <td>37</td>
+    <td>小林 正樹</td>
+    <td>Masaki J Kobayashi</td>
+    <td>The genome of Shorea leprosula (Dipterocarpaceae) highlights the ecological relevance of drought in aseasonal tropical rainforests</td>
+    <td>Communications biology. 2021 Oct 7;4(1):1166.</td>
+    <td>34620991</td>
+    <td>doi: 10.1038/s42003-021-02682-1
+</td>
+</tr>
+<tr>
+    <td>38</td>
+    <td>浜口 悠</td>
+    <td>Yu Hamaguchi</td>
+    <td>Impact of human gene annotations on RNA-seq differential expression analysis</td>
+    <td>BMC genomics. 2021 Oct 8;22(1):730.</td>
+    <td>34625021</td>
+    <td>doi: 10.1186/s12864-021-08038-7
+</td>
+</tr>
+<tr>
+    <td>39</td>
+    <td>植松 真章</td>
+    <td>Masaaki Uematsu</td>
+    <td>Raman microscopy-based quantification of the physical properties of intracellular lipids</td>
+    <td>Communications biology. 2021 Oct 8;4(1):1176.</td>
+    <td>34625633</td>
+    <td>doi: 10.1038/s42003-021-02679-w
+</td>
+</tr>
+<tr>
+    <td>40</td>
+    <td>佐藤 綾</td>
+    <td>Aya Satoh</td>
+    <td>De novo assembly and annotation of the mangrove cricket genome</td>
+    <td>BMC research notes. 2021 Oct 9;14(1):387.</td>
+    <td>34627387</td>
+    <td>doi: 10.1186/s13104-021-05798-z
+</td>
+</tr>
+<tr>
+    <td>41</td>
+    <td>山﨑 曜</td>
+    <td>Yo Y Yamasaki</td>
+    <td>Gudgeon fish with and without genetically determined countershading coexist in heterogeneous littoral environments of an ancient lake</td>
+    <td>Ecology and evolution. 2021 Aug 31;11(19):13283-13294.</td>
+    <td>34646469</td>
+    <td>doi: 10.1002/ece3.8050
+</td>
+</tr>
+<tr>
+    <td>42</td>
+    <td>杉本 竜太</td>
+    <td>Ryota Sugimoto</td>
+    <td>Comprehensive discovery of CRISPR-targeted terminally redundant sequences in the human gut metagenome: Viruses, plasmids, and more</td>
+    <td>PLoS computational biology. 2021 Oct 21;17(10):e1009428.</td>
+    <td>34673779</td>
+    <td>doi: 10.1371/journal.pcbi.1009428
+</td>
+</tr>
+<tr>
+    <td>43</td>
+    <td>中村 保一</td>
+    <td>Yasukazu Nakamura</td>
+    <td>Genome sequencing of the NIES Cyanobacteria collection with a focus on the heterocyst-forming clade.</td>
+    <td>DNA research : an international journal for rapid publication of reports on genes and genomes. 2021 Oct 11;28(6):dsab024.</td>
+    <td>34677568</td>
+    <td>doi: 10.1093/dnares/dsab024
+</td>
+</tr>
+<tr>
+    <td>44</td>
+    <td>安河内 彦輝</td>
+    <td>Yoshiki Yasukochi </td>
+    <td>Upregulation of cathepsin L gene under mild cold conditions in young Japanese male adults</td>
+    <td>Journal of physiological anthropology. 2021 Oct 22;40(1):16.</td>
+    <td>34686211</td>
+    <td>doi: 10.1186/s40101-021-00267-9
+</td>
+</tr>
+<tr>
+    <td>45</td>
+    <td>谷澤 靖洋, 矢倉 勝, 中村 保一</td>
+    <td>Yasuhiro Tanizawa, Masaru Yagura, Yasukazu Nakamura</td>
+    <td>Identification of the sex-determining factor in the liverwort Marchantia polymorpha reveals unique evolution of sex chromosomes in a haploid system.</td>
+    <td>Current biology : CB. 2021 Dec 20;31(24):5522-5532.e7.</td>
+    <td>34735792</td>
+    <td>doi: 10.1016/j.cub.2021.10.023
+</td>
+</tr>
+<tr>
+    <td>46</td>
+    <td>宮澤 清太</td>
+    <td>Seita Miyazawa</td>
+    <td>Studies of Turing pattern formation in zebrafish skin</td>
+    <td>Philosophical transactions. Series A, Mathematical, physical, and engineering sciences. 2021 Dec 27;379(2213):20200274.</td>
+    <td>34743596</td>
+    <td>doi: 10.1098/rsta.2020.0274
+</td>
+</tr>
+<tr>
+    <td>47</td>
+    <td>谷澤 靖洋, 遠野 雅徳</td>
+    <td>Yasuhiro Tanizawa, Masanori Tohno</td>
+    <td>Clostridium zeae sp. nov., isolated from corn silage</td>
+    <td>International journal of systematic and evolutionary microbiology. 2021 Nov;71(11).</td>
+    <td>34748474</td>
+    <td>doi: 10.1099/ijsem.0.005088
+</td>
+</tr>
+<tr>
+    <td>48</td>
+    <td>中川 草</td>
+    <td>So Nakagawa</td>
+    <td>An ancient retroviral RNA element hidden in mammalian genomes and its involvement in co-opted retroviral gene regulation</td>
+    <td>Retrovirology. 2021 Nov 10;18(1):36.</td>
+    <td>34753509</td>
+    <td>doi: 10.1186/s12977-021-00580-2
+</td>
+</tr>
+<tr>
+    <td>49</td>
+    <td>Evariste Tshibangu-Kabamba</td>
+    <td>Evariste Tshibangu-Kabamba </td>
+    <td>High-Resolution Linear Epitope Mapping of the Receptor Binding Domain of SARS-CoV-2 Spike Protein in COVID-19 mRNA Vaccine Recipients</td>
+    <td>Microbiology spectrum. 2021 Dec 22;9(3):e0096521.</td>
+    <td>34756082</td>
+    <td>doi: 10.1128/Spectrum.00965-21
+</td>
+</tr>
+<tr>
+    <td>50</td>
+    <td>神澤 秀明</td>
+    <td>Hideaki Kanzawa-Kiriyama</td>
+    <td>Triangulation supports agricultural spread of the Transeurasian languages</td>
+    <td>Nature. 2021 Nov;599(7886):616-621.</td>
+    <td>34759322</td>
+    <td>doi: 10.1038/s41586-021-04108-8
+</td>
+</tr>
+<tr>
+    <td>51</td>
+    <td>中尾 亮</td>
+    <td>Ryo Nakao</td>
+    <td>Complete Genome Sequence of Leptospira kobayashii Strain E30, Isolated from Soil in Japan</td>
+    <td>Microbiology resource announcements. 2021 Nov 11;10(45):e0090721.</td>
+    <td>34761960</td>
+    <td>doi: 10.1128/MRA.00907-21
+</td>
+</tr>
+<tr>
+    <td>52</td>
+    <td>加藤 有己</td>
+    <td>Yuki Kato </td>
+    <td>An Aicardi-Goutieres syndrome-causative point mutation in Adar1 gene invokes multi-organ inflammation and late-onset encephalopathy in mice</td>
+    <td>Journal of immunology (Baltimore, Md. : 1950). 2021 Dec 15;207(12):3016-3027.</td>
+    <td>34772697</td>
+    <td>doi: 10.4049/jimmunol.2100526
+</td>
+</tr>
+<tr>
+    <td>53</td>
+    <td>津田 勝利</td>
+    <td>Katsutoshi Tsuda</td>
+    <td>Collection, preservation and distribution of Oryza genetic resources by the National Bioresource Project RICE (NBRP-RICE)</td>
+    <td>Breeding science. 2021 Jun;71(3):291-298.</td>
+    <td>34776736</td>
+    <td>doi: 10.1270/jsbbs.21005
+</td>
+</tr>
+<tr>
+    <td>54</td>
+    <td>下村 晃一郎</td>
+    <td>Koichiro Shimomura</td>
+    <td>Identification of quantitative trait loci for powdery mildew resistance in highly resistant cucumber (Cucumis sativus L.) using ddRAD-seq analysis</td>
+    <td>Breeding science. 2021 Jun;71(3):326-333.</td>
+    <td>34776739</td>
+    <td>doi: 10.1270/jsbbs.20141
+</td>
+</tr>
+<tr>
+    <td>55</td>
+    <td>趙 世涛</td>
+    <td>Shitao Zhao</td>
+    <td>Multi-resBind: a residual network-based multi-label classifier for in vivo RNA binding prediction and preference visualization</td>
+    <td>BMC bioinformatics. 2021 Nov 15;22(1):554.</td>
+    <td>34781902</td>
+    <td>doi: 10.1186/s12859-021-04430-y
+</td>
+</tr>
+<tr>
+    <td>56</td>
+    <td>美世 一守</td>
+    <td>Kazumori Mise</td>
+    <td>Undervalued Pseudo-nifH Sequences in Public Databases Distort Metagenomic Insights into Biological Nitrogen Fixers</td>
+    <td>mSphere. 2021 Dec 22;6(6):e0078521.</td>
+    <td>34787447</td>
+    <td>doi: 10.1128/msphere.00785-21
+</td>
+</tr>
+<tr>
+    <td>57</td>
+    <td>水口 洋平, 豊田 敦</td>
+    <td>Yohei Minakuchi, Atsushi Toyoda</td>
+    <td>Genome sequencing of the multicellular alga Astrephomene provides insights into convergent evolution of germ-soma differentiation</td>
+    <td>Scientific reports. 2021 Nov 22;11(1):22231.</td>
+    <td>34811380</td>
+    <td>doi: 10.1038/s41598-021-01521-x
+</td>
+</tr>
+<tr>
+    <td>58</td>
+    <td>川本 麻祐子, 河田 雅圭</td>
+    <td>Mayuko Kawamoto, Masakado Kawata</td>
+    <td>Genetic basis of orange spot formation in the guppy (Poecilia reticulata)</td>
+    <td>BMC ecology and evolution. 2021 Nov 25;21(1):211.</td>
+    <td>34823475</td>
+    <td>doi: 10.1186/s12862-021-01942-2
+</td>
+</tr>
+<tr>
+    <td>59</td>
+    <td>佐藤 健吾</td>
+    <td>Kengo Sato</td>
+    <td>A Max-Margin Model for Predicting Residue-Base Contacts in Protein-RNA Interactions</td>
+    <td>Life (Basel, Switzerland). 2021 Oct 25;11(11):1135.</td>
+    <td>34833011</td>
+    <td>doi: 10.3390/life11111135
+</td>
+</tr>
+<tr>
+    <td>60</td>
+    <td>Vo Phuoc Tuan, 矢原 耕史</td>
+    <td>Vo Phuoc Tuan, Koji Yahara</td>
+    <td>Genome-wide association study of gastric cancer- and duodenal ulcer-derived Helicobacter pylori strains reveals discriminatory genetic variations and novel oncoprotein candidates</td>
+    <td>Microbial genomics. 2021 Nov;7(11):000680.</td>
+    <td>34846284</td>
+    <td>doi: 10.1099/mgen.0.000680
+</td>
+</tr>
+<tr>
+    <td>61</td>
+    <td>有泉 亨</td>
+    <td>Tohru Ariizumi</td>
+    <td>Organelle genome assembly uncovers the dynamic genome reorganization and cytoplasmic male sterility associated genes in tomato</td>
+    <td>Horticulture research. 2021 Dec 1;8(1):250.</td>
+    <td>34848681</td>
+    <td>doi: 10.1038/s41438-021-00676-y
+</td>
+</tr>
+<tr>
+    <td>62</td>
+    <td>渡邊 美穂</td>
+    <td>Miho Watanabe</td>
+    <td>Mariniplasma anaerobium gen. nov., sp. nov., a novel anaerobic marine mollicute, and proposal of three novel genera to reclassify members of Acholeplasma clusters II-IV</td>
+    <td>International journal of systematic and evolutionary microbiology. 2021 Dec;71(12).</td>
+    <td>34874244</td>
+    <td>doi: 10.1099/ijsem.0.005138
+</td>
+</tr>
+<tr>
+    <td>63</td>
+    <td>新里 宙也</td>
+    <td>Chuya Shinzato</td>
+    <td>Whole-Genome Sequencing Highlights Conservative Genomic Strategies of a Stress-Tolerant, Long-Lived Scleractinian Coral, Porites australiensis Vaughan, 1918</td>
+    <td>Genome biology and evolution. 2021 Dec 1;13(12):evab270.</td>
+    <td>34878117</td>
+    <td>doi: 10.1093/gbe/evab270
+</td>
+</tr>
+<tr>
+    <td>64</td>
+    <td>遠野 雅徳, 谷澤 靖洋</td>
+    <td>Masanori Tohno, Yasuhiro Tanizawa</td>
+    <td>Lentilactobacillus fungorum sp. nov., isolated from spent mushroom substrates</td>
+    <td>International journal of systematic and evolutionary microbiology. 2021 Dec;71(12).</td>
+    <td>34913426</td>
+    <td>doi: 10.1099/ijsem.0.005184
+</td>
+</tr>
+<tr>
+    <td>65</td>
+    <td>大島 一里</td>
+    <td>Kazusato Ohshima </td>
+    <td>Genomic Epidemiology and Evolution of Scallion Mosaic Potyvirus From Asymptomatic Wild Japanese Garlic</td>
+    <td>Frontiers in microbiology. 2021 Dec 8;12:789596.</td>
+    <td>34956155</td>
+    <td>doi: 10.3389/fmicb.2021.789596
+</td>
+</tr>
+<tr>
+    <td>66</td>
+    <td>武藤 吉徳</td>
+    <td>Yoshinori Muto</td>
+    <td>Neuropsychiatric Adverse Events of Montelukast: An Analysis of Real-World Datasets and drug−gene Interaction Network</td>
+    <td>Frontiers in pharmacology. 2021 Dec 20;12:764279.</td>
+    <td>34987393</td>
+    <td>doi: 10.3389/fphar.2021.764279
+</td>
+</tr>
+<tr>
+    <td>67</td>
+    <td>松尾 俊彦</td>
+    <td>Toshihiko Matsuo </td>
+    <td>Whole Exome-Sequencing of Pooled Genomic DNA Samples to Detect Quantitative Trait Loci in Esotropia and Exotropia of Strabismus in Japanese</td>
+    <td>Life (Basel, Switzerland). 2021 Dec 27;12(1):41.</td>
+    <td>35054434</td>
+    <td>doi: 10.3390/life12010041
+</td>
+</tr>
+<tr>
+    <td>68</td>
+    <td>花野 滋</td>
+    <td>Shigeru Hanano</td>
+    <td>Development of the Binary Vector pTACAtg1 for Stable Gene Expression in Plant; Reduction of Gene Silencing in Transgenic Plants Carrying the Target Gene with Long Flanking Sequences</td>
+    <td>Plant biotechnology (Tokyo, Japan). 2021 Dec 25;38(4):391-400.</td>
+    <td>35087303</td>
+    <td>doi: 10.5511/plantbiotechnology.21.0823a
+</td>
+</tr>
+<tr>
+    <td>69</td>
+    <td>田崎 啓介</td>
+    <td>Keisuke Tasaki</td>
+    <td>Identification and characterization of xanthone biosynthetic genes contributing to the vivid red coloration of red-flowered gentian</td>
+    <td>The Plant journal : for cell and molecular biology. 2021 Sep;107(6):1711-1723.</td>
+    <td>34245606</td>
+    <td>doi: 10.1111/tpj.15412
+</td>
+</tr>
+<tr>
+    <td>70</td>
+    <td>長﨑 正朗</td>
+    <td>Masao Nagasaki</td>
+    <td>Practical guide for managing large-scale human genome data in research</td>
+    <td>Journal of human genetics. 2021 Jan;66(1):39-52.</td>
+    <td>33097812</td>
+    <td>doi: 10.1038/s10038-020-00862-1
+</td>
+</tr>
+<tr>
+    <td>71</td>
+    <td>丹野 広貴</td>
+    <td>Hiroki Tanno</td>
+    <td>Characterization of fructooligosaccharide metabolism and fructooligosaccharide-degrading enzymes in human commensal butyrate producers</td>
+    <td>Gut microbes. 2021 Jan-Dec;13(1):1-20.</td>
+    <td>33439065</td>
+    <td>doi: 10.1080/19490976.2020.1869503
+</td>
+</tr>
+<tr>
+    <td>72</td>
+    <td>河合 洋介</td>
+    <td>Yosuke Kawai</td>
+    <td>Genome-wide SNP data of Izumo and Makurazaki populations support inner-dual structure model for origin of Yamato people</td>
+    <td>Journal of human genetics. 2021 Jul;66(7):681-687.</td>
+    <td>33495571</td>
+    <td>doi: 10.1038/s10038-020-00898-3
+</td>
+</tr>
+<tr>
+    <td>73</td>
+    <td>堀江 真行</td>
+    <td>Masayuki Horie</td>
+    <td>Identification of novel avian and mammalian deltaviruses provides new insights into deltavirus evolution</td>
+    <td>Virus evolution. 2021 Feb 12;7(1):veab003.</td>
+    <td>33614159</td>
+    <td>doi: 10.1093/ve/veab003
+</td>
+</tr>
+<tr>
+    <td>74</td>
+    <td>和智 仲是</td>
+    <td>Nakatada Wachi</td>
+    <td>Genomic population structure of sympatric sexual and asexual populations in a parasitic wasp, Meteorus pulchricornis (Hymenoptera: Braconidae), inferred from six hundred single-nucleotide polymorphism loci</td>
+    <td>Molecular ecology. 2021 Apr;30(7):1612-1623.</td>
+    <td>33634920</td>
+    <td>doi: 10.1111/mec.15834
+</td>
+</tr>
+<tr>
+    <td>75</td>
+    <td>西田 奈央</td>
+    <td>Nao Nishida</td>
+    <td>Importance of HBsAg recognition by HLA molecules as revealed by responsiveness to different hepatitis B vaccines</td>
+    <td>Scientific reports. 2021 Mar 2;11(1):3703.</td>
+    <td>33654122</td>
+    <td>doi: 10.1038/s41598-021-82986-8
+</td>
+</tr>
+<tr>
+    <td>76</td>
+    <td>谷澤 靖洋, 津田 勝利, 中村 保一</td>
+    <td>Yasuhiro Tanizawa, Katsutoshi Tsuda, Yasukazu Nakamura</td>
+    <td>OryzaGenome2.1: Database of Diverse Genotypes in Wild Oryza Species</td>
+    <td>Rice (New York, N.Y.). 2021 Mar 4;14(1):24.</td>
+    <td>33661371</td>
+    <td>doi: 10.1186/s12284-021-00468-x
+</td>
+</tr>
+<tr>
+    <td>77</td>
+    <td>竹崎 直子</td>
+    <td>Naoko Takezaki</td>
+    <td>Resolving the Early Divergence Pattern of Teleost Fish Using Genome-Scale Data</td>
+    <td>Genome biology and evolution. 2021 May 7;13(5):evab052.</td>
+    <td>33739405</td>
+    <td>doi: 10.1093/gbe/evab052
+</td>
+</tr>
+<tr>
+    <td>78</td>
+    <td>川久保 修佑</td>
+    <td>Shusuke Kawakubo</td>
+    <td>Genomic analysis of the brassica pathogen turnip mosaic potyvirus reveals its spread along the former trade routes of the Silk Road</td>
+    <td>Proceedings of the National Academy of Sciences of the United States of America. 2021 Mar 23;118(12):e2021221118.</td>
+    <td>33741737</td>
+    <td>doi: 10.1073/pnas.2021221118
+</td>
+</tr>
+<tr>
+    <td>79</td>
+    <td>殿崎 薫</td>
+    <td>Kaoru Tonosaki</td>
+    <td>Mutation of the imprinted gene OsEMF2a induces autonomous endosperm development and delayed cellularization in rice</td>
+    <td>The Plant cell. 2021 Mar 22;33(1):85-103.</td>
+    <td>33751094</td>
+    <td>doi: 10.1093/plcell/koaa006
+</td>
+</tr>
+<tr>
+    <td>80</td>
+    <td>松尾 芳隆</td>
+    <td>Yoshitaka Matsuo</td>
+    <td>The ribosome collision sensor Hel2 functions as preventive quality control in the secretory pathway</td>
+    <td>Cell reports. 2021 Mar 23;34(12):108877.</td>
+    <td>33761353</td>
+    <td>doi: 10.1016/j.celrep.2021.108877
+</td>
+</tr>
+<tr>
+    <td>81</td>
+    <td>矢原 耕史</td>
+    <td>Koji Yahara</td>
+    <td>Emergence and evolution of antimicrobial resistance genes and mutations in Neisseria gonorrhoeae</td>
+    <td>Genome medicine. 2021 Mar 30;13(1):51.</td>
+    <td>33785063</td>
+    <td>doi: 10.1186/s13073-021-00860-8
+</td>
+</tr>
+<tr>
+    <td>82</td>
+    <td>吉武 和敏</td>
+    <td>Kazutoshi Yoshitake </td>
+    <td>Estimation of tuna population by the improved analytical pipeline of unique molecular identifier-assisted HaCeD-Seq (haplotype count from eDNA)</td>
+    <td>Scientific reports. 2021 Apr 12;11(1):7031.</td>
+    <td>33846364</td>
+    <td>doi: 10.1038/s41598-021-86190-6
+</td>
+</tr>
+<tr>
+    <td>83</td>
+    <td>西井 かなえ</td>
+    <td>Kanae Nishii</td>
+    <td>Mix and match: Patchwork domain evolution of the land plant-specific Ca2+-permeable mechanosensitive channel MCA</td>
+    <td>PloS one. 2021 Apr 15;16(4):e0249735.</td>
+    <td>33857196</td>
+    <td>doi: 10.1371/journal.pone.0249735
+</td>
+</tr>
+<tr>
+    <td>84</td>
+    <td>前野 慎太朗, 遠藤 明仁, 中条 聡</td>
+    <td>Shintaro Maeno, Akihito Endo</td>
+    <td>Niche-specific adaptation of Lactobacillus helveticus strains isolated from malt whisky and dairy fermentations</td>
+    <td>Microbial genomics. 2021 Apr;7(4):000560.</td>
+    <td>33900907</td>
+    <td>doi: 10.1099/mgen.0.000560
+</td>
+</tr>
+<tr>
+    <td>85</td>
+    <td>加藤 有己</td>
+    <td>Yuki Kato</td>
+    <td>RNA editing at a limited number of sites is sufficient to prevent MDA5 activation in the mouse brain</td>
+    <td>PLoS genetics. 2021 May 13;17(5):e1009516.</td>
+    <td>33983932</td>
+    <td>doi: 10.1371/journal.pgen.1009516
+</td>
+</tr>
+<tr>
+    <td>86</td>
+    <td>坊農 秀雅</td>
+    <td>Hidemasa Bono</td>
+    <td>De novo transcriptome analysis for examination of the nutrition metabolic system related to the evolutionary process through which stick insects gain the ability of flight (Phasmatodea).</td>
+    <td>BMC research notes. 2021 May 13;14(1):182.</td>
+    <td>33985569</td>
+    <td>doi: 10.1186/s13104-021-05600-0
+</td>
+</tr>
+<tr>
+    <td>87</td>
+    <td>川崎 純菜, 堀江 真行</td>
+    <td>Junna Kawasaki, Masayuki Horie</td>
+    <td>100-My history of bornavirus infections hidden in vertebrate genomes</td>
+    <td>Proceedings of the National Academy of Sciences of the United States of America. 2021 May 18;118(20):e2026235118.</td>
+    <td>33990470</td>
+    <td>doi: 10.1073/pnas.2026235118
+</td>
+</tr>
+<tr>
+    <td>88</td>
+    <td>本道 栄一</td>
+    <td>Eiichi Hondo</td>
+    <td>Viral-derived DNA invasion and individual variation in an Indonesian population of large flying fox Pteropus vampyrus</td>
+    <td>The Journal of veterinary medical science. 2021 Jul 2;83(7):1068-1074.</td>
+    <td>33994419</td>
+    <td>doi: 10.1292/jvms.21-0115
+</td>
+</tr>
+<tr>
+    <td>89</td>
+    <td>花田 耕介</td>
+    <td>Kousuke Hanada</td>
+    <td>Positive selective sweeps of epigenetic mutations regulating specialized metabolites in plants</td>
+    <td>Genome research. 2021 Jun;31(6):1060-1068.</td>
+    <td>34006571</td>
+    <td>doi: 10.1101/gr.271726.120
+</td>
+</tr>
+<tr>
+    <td>90</td>
+    <td>水口 洋平, 豊田 敦</td>
+    <td>Yohei Minakuchi, Atsushi Toyoda</td>
+    <td>Three genomes in the algal genus Volvox reveal the fate of a haploid sex-determining region after a transition to homothallism</td>
+    <td>Proceedings of the National Academy of Sciences of the United States of America. 2021 May 25;118(21):e2100712118.</td>
+    <td>34011609</td>
+    <td>doi: 10.1073/pnas.2100712118
+</td>
+</tr>
+<tr>
+    <td>91</td>
+    <td>石神 宥真</td>
+    <td>Yuma Ishigami</td>
+    <td>A single m6A modification in U6 snRNA diversifies exon sequence at the 5' splice site</td>
+    <td>Nature communications. 2021 May 28;12(1):3244.</td>
+    <td>34050143</td>
+    <td>doi: 10.1038/s41467-021-23457-6
+</td>
+</tr>
+<tr>
+    <td>92</td>
+    <td>中川 草</td>
+    <td>So Nakagawa</td>
+    <td>SARS-CoV-2 spike L452R variant evades cellular immunity and increases infectivity</td>
+    <td>Cell host &amp; microbe. 2021 Jul 14;29(7):1124-1136.e11.</td>
+    <td>34171266</td>
+    <td>doi: 10.1016/j.chom.2021.06.006
+</td>
+</tr>
+<tr>
+    <td>93</td>
+    <td>岩切 淳一</td>
+    <td>Junichi Iwakiri</td>
+    <td>m6A modification of HSATIII lncRNAs regulates temperature-dependent splicing</td>
+    <td>The EMBO journal. 2021 Aug 2;40(15):e107976.</td>
+    <td>34184765</td>
+    <td>doi: 10.15252/embj.2021107976
+</td>
+</tr>
+<tr>
+    <td>94</td>
+    <td>平野 雅規</td>
+    <td>Masaki Hirano</td>
+    <td>Newly established patient-derived organoid model of intracranial meningioma</td>
+    <td>Neuro-oncology. 2021 Nov 2;23(11):1936-1948.</td>
+    <td>34214169</td>
+    <td>doi: 10.1093/neuonc/noab155
+</td>
+</tr>
+<tr>
+    <td>95</td>
+    <td>市原 知哉, 松本 有樹修</td>
+    <td>Kazuya Ichihara, Akinobu Matsumoto</td>
+    <td>Combinatorial analysis of translation dynamics reveals eIF2 dependence of translation initiation at near-cognate codons</td>
+    <td>Nucleic acids research. 2021 Jul 21;49(13):7298-7317.</td>
+    <td>34226921</td>
+    <td>doi: 10.1093/nar/gkab549
+</td>
+</tr>
+<tr>
+    <td>96</td>
+    <td>榎本 拓央</td>
+    <td>Takuo Enomoto</td>
+    <td>Differences in mineral accumulation and gene expression profiles between two metal hyperaccumulators, Noccaea japonica and Noccaea caerulescens ecotype Ganges, under excess nickel condition</td>
+    <td>Plant signaling &amp; behavior. 2021 Oct 3;16(10):1945212.</td>
+    <td>34227899</td>
+    <td>doi: 10.1080/15592324.2021.1945212
+</td>
+</tr>
+<tr>
+    <td>97</td>
+    <td>小野口 真広</td>
+    <td>Masahiro Onoguchi</td>
+    <td>Binding patterns of RNA-binding proteins to repeat-derived RNA sequences reveal putative functional RNA elements</td>
+    <td>NAR genomics and bioinformatics. 2021 Jul 2;3(3):lqab055.</td>
+    <td>34235430</td>
+    <td>doi: 10.1093/nargab/lqab055
+</td>
+</tr>
+<tr>
+    <td>98</td>
+    <td>原 雄一郎, 國枝 武和</td>
+    <td>Yuichiro Hara, Takekazu Kunieda</td>
+    <td>Parallel evolution of trehalose production machinery in anhydrobiotic animals via recurrent gene loss and horizontal transfer</td>
+    <td>Open biology. 2021 Jul;11(7):200413.</td>
+    <td>34255978</td>
+    <td>doi: 10.1098/rsob.200413
+</td>
+</tr>
+<tr>
+    <td>99</td>
+    <td>草間 和哉</td>
+    <td>Kazuya Kusama</td>
+    <td>Day 7 Embryos Change the Proteomics and Exosomal Micro-RNAs Content of Bovine Uterine Fluid: Involvement of Innate Immune Functions</td>
+    <td>Frontiers in genetics. 2021 Jun 28;12:676791.</td>
+    <td>34262596</td>
+    <td>doi: 10.3389/fgene.2021.676791
+</td>
+</tr>
+<tr>
+    <td>100</td>
+    <td>遠野 雅徳</td>
+    <td>Masanori Tohno</td>
+    <td>Lactobacillus corticis sp. nov., isolated from hardwood bark</td>
+    <td>International journal of systematic and evolutionary microbiology. 2021 Jul;71(7).</td>
+    <td>34264810</td>
+    <td>doi: 10.1099/ijsem.0.004882
+</td>
+</tr>
+<tr>
+    <td>101</td>
+    <td>岩上 哲史</td>
+    <td>Satoshi Iwakami</td>
+    <td>Gene expression shapes the patterns of parallel evolution of herbicide resistance in the agricultural weed Monochoria vaginalis</td>
+    <td>The New phytologist. 2021 Oct;232(2):928-940.</td>
+    <td>34270808</td>
+    <td>doi: 10.1111/nph.17624
+</td>
+</tr>
+<tr>
+    <td>102</td>
+    <td>堀江 真行</td>
+    <td>Masayuki Horie</td>
+    <td>Identification of a novel filovirus in a common lancehead (Bothrops atrox (Linnaeus, 1758))</td>
+    <td>The Journal of veterinary medical science. 2021 Sep 27;83(9):1485-1488.</td>
+    <td>34275961</td>
+    <td>doi: 10.1292/jvms.21-0285
+</td>
+</tr>
+<tr>
+    <td>103</td>
+    <td>大野 翔</td>
+    <td>Sho Ohno</td>
+    <td>Post-transcriptional gene silencing of CYP76AD controls betalain biosynthesis in bracts of bougainvillea</td>
+    <td>Journal of experimental botany. 2021 Oct 26;72(20):6949-6962.</td>
+    <td>34279632</td>
+    <td>doi: 10.1093/jxb/erab340
+</td>
+</tr>
+<tr>
+    <td>104</td>
+    <td>田中 義行</td>
+    <td>Yoshiyuki Tanaka</td>
+    <td>Capsaicinoid biosynthesis in the pericarp of chili pepper fruits is associated with a placental septum‐like transcriptome profile and tissue structure</td>
+    <td>Plant cell reports. 2021 Oct;40(10):1859-1874.</td>
+    <td>34283265</td>
+    <td>doi: 10.1007/s00299-021-02750-0
+</td>
+</tr>
+<tr>
+    <td>105</td>
+    <td>太田 亮作</td>
+    <td>Ryosaku Ota</td>
+    <td>Prediction of HIV drug resistance based on the 3D protein structure: Proposal of molecular field mapping</td>
+    <td>PloS one. 2021 Aug 4;16(8):e0255693.</td>
+    <td>34347839</td>
+    <td>doi: 10.1371/journal.pone.0255693
+</td>
+</tr>
+<tr>
+    <td>106</td>
+    <td>仁田 暁大, 市原 知哉</td>
+    <td>Akihiro Nita, Kazuya Ichihara,</td>
+    <td>A ubiquitin-like protein encoded by the "noncoding" RNA TINCR promotes keratinocyte proliferation and wound healing</td>
+    <td>PLoS genetics. 2021 Aug 5;17(8):e1009686.</td>
+    <td>34351912</td>
+    <td>doi: 10.1371/journal.pgen.1009686
+</td>
+</tr>
+<tr>
+    <td>107</td>
+    <td>瀬川 天太, 高木 宏樹</td>
+    <td>Tenta Segawa, Hiroki Takagi</td>
+    <td>Sat-BSA: an NGS-based method using local de novo assembly of long reads for rapid identification of genomic structural variations associated with agronomic traits</td>
+    <td>Breeding science. 2021 Jun;71(3):299-312.</td>
+    <td>34776737</td>
+    <td>doi: 10.1270/jsbbs.20148
+</td>
+</tr>
+<tr>
+    <td>108</td>
+    <td>矢原 耕史</td>
+    <td>Koji Yahara</td>
+    <td>Long-read metagenomics using PromethION uncovers oral bacteriophages and their interaction with host bacteria</td>
+    <td>Nature communications. 2021 Jan 4;12(1):27.</td>
+    <td>33397904</td>
+    <td>doi: 10.1038/s41467-020-20199-9
+</td>
+</tr>
+<tr>
+    <td>109</td>
+    <td>本道 栄一</td>
+    <td>Eiichi Hondo</td>
+    <td>Dispersal history of Miniopterus fuliginosus bats and their associated viruses in east Asia</td>
+    <td>PloS one. 2021 Jan 14;16(1):e0244006.</td>
+    <td>33444317</td>
+    <td>doi: 10.1371/journal.pone.0244006
+</td>
+</tr>
+<tr>
+    <td>110</td>
+    <td>岸田 拓士, 郷 康広</td>
+    <td>Takushi Kishida, Yasuhiro Go</td>
+    <td>Population history and genomic admixture of sea snakes of the genus Laticauda in the West Pacific</td>
+    <td>Molecular phylogenetics and evolution. 2021 Feb;155:107005.</td>
+    <td>33160037</td>
+    <td>doi: 10.1016/j.ympev.2020.107005
+</td>
+</tr>
+<tr>
+    <td>111</td>
+    <td>前野 慎太朗, 遠藤 明仁</td>
+    <td>Shintaro Maeno, Akihito Endo</td>
+    <td>Unique niche-specific adaptation of fructophilic lactic acid bacteria and proposal of three Apilactobacillus species as novel members of the group</td>
+    <td>BMC microbiology. 2021 Feb 9;21(1):41.</td>
+    <td>33563209</td>
+    <td>doi: 10.1186/s12866-021-02101-9
+</td>
+</tr>
+<tr>
+    <td>112</td>
+    <td>鈴木 郁夫</td>
+    <td>Ikuo K Suzuki</td>
+    <td>Spatial and temporal diversity of DCLK1 isoforms in developing mouse brain</td>
+    <td>Neuroscience research. 2021 Sep;170:154-165.</td>
+    <td>33485913</td>
+    <td>doi: 10.1016/j.neures.2020.12.004
+</td>
+</tr>
+<tr>
+    <td>113</td>
+    <td>堀江 真行</td>
+    <td>Masayuki Horie</td>
+    <td>Identification of a reptile lyssavirus in Anolis allogus provided novel insights into lyssavirus evolution</td>
+    <td>Virus genes. 2021 Feb;57(1):40-49.</td>
+    <td>33159637</td>
+    <td>doi: 10.1007/s11262-020-01803-y
+</td>
+</tr>
+<tr>
+    <td>114</td>
+    <td>西井 かなえ</td>
+    <td>Kanae Nishii</td>
+    <td>Phylogenomics of Gesneriaceae using targeted capture of nuclear genes</td>
+    <td>Molecular phylogenetics and evolution. 2021 Apr;157:107068.</td>
+    <td>33422648</td>
+    <td>doi: 10.1016/j.ympev.2021.107068
+</td>
+</tr>
+<tr>
+    <td>115</td>
+    <td>曽 超</td>
+    <td>Chao Zeng</td>
+    <td>Association analysis of repetitive elements and R-loop formation across species</td>
+    <td>Mobile DNA. 2021 Jan 20;12(1):3.</td>
+    <td>33472695</td>
+    <td>doi: 10.1186/s13100-021-00231-5
+</td>
+</tr>
+<tr>
+    <td>116</td>
+    <td>Rai Amit, ライ メガ, 高橋 弘喜</td>
+    <td>Amit Rai, Megha Rai, Hiroki Takahashi</td>
+    <td>Chromosome-level genome assembly of Ophiorrhiza pumila reveals the evolution of camptothecin biosynthesis</td>
+    <td>Nature communications. 2021 Jan 15;12(1):405.</td>
+    <td>33452249</td>
+    <td>doi: 10.1038/s41467-020-20508-2
+</td>
+</tr>
+<tr>
+    <td>117</td>
+    <td>三橋 里美</td>
+    <td>Satomi Mitsuhashi</td>
+    <td>Genome-wide survey of tandem repeats by nanopore sequencing shows that disease-associated repeats are more polymorphic in the general population</td>
+    <td>BMC medical genomics. 2021 Jan 7;14(1):17.</td>
+    <td>33413375</td>
+    <td>doi: 10.1186/s12920-020-00853-3
+</td>
+</tr>
+<tr>
+    <td>118</td>
+    <td>有泉 亨</td>
+    <td>Tohru Ariizumi</td>
+    <td>De novo genome assembly of two tomato ancestors, Solanum pimpinellifolium and Solanum lycopersicum var. cerasiforme, by long-read sequencing</td>
+    <td>DNA research : an international journal for rapid publication of reports on genes and genomes. 2021 Jan 19;28(1):dsaa029.</td>
+    <td>33475141</td>
+    <td>doi: 10.1093/dnares/dsaa029
+</td>
+</tr>
+<tr>
+    <td>119</td>
+    <td>水口 洋平, 豊田 敦</td>
+    <td>Yohei Minakuchi, Atsushi Toyoda</td>
+    <td>Comparative analysis using the draft genome sequence of California poppy (Eschscholzia californica) for exploring the candidate genes involved in benzylisoquinoline alkaloid biosynthesis</td>
+    <td>Bioscience, biotechnology, and biochemistry. 2021 Mar 24;85(4):851-859.</td>
+    <td>33589920</td>
+    <td>doi: 10.1093/bbb/zbaa091
+</td>
+</tr>
+<tr>
+    <td>120</td>
+    <td>大泉 祐介</td>
+    <td>Yusuke Oizumi</td>
+    <td>Complete sequences of Schizosaccharomyces pombe subtelomeres reveal multiple patterns of genome variation</td>
+    <td>Nature communications. 2021 Jan 27;12(1):611.</td>
+    <td>33504776</td>
+    <td>doi: 10.1038/s41467-020-20595-1
+</td>
+</tr>
+<tr>
+    <td>121</td>
+    <td>小野口 玲菜, 秋光 信佳</td>
+    <td>Rena Onoguchi-Mizutani, Nobuyoshi Akimitsu</td>
+    <td>Identification of novel heat shock-induced long noncoding RNA in human cells</td>
+    <td>Journal of biochemistry. 2021 Apr 29;169(4):497-505.</td>
+    <td>33170212</td>
+    <td>doi: 10.1093/jb/mvaa126
+</td>
+</tr>
+<tr>
+    <td>122</td>
+    <td>渡部 裕介, 大橋 順</td>
+    <td>Yusuke Watanabe, Jun Ohashi</td>
+    <td>Prefecture-level population structure of the Japanese based on SNP genotypes of 11,069 individuals</td>
+    <td>Journal of human genetics. 2021 Apr;66(4):431-437.</td>
+    <td>33051579</td>
+    <td>doi: 10.1038/s10038-020-00847-0
+</td>
+</tr>
+<tr>
+    <td>123</td>
+    <td>小野 幸輝</td>
+    <td>Yukiteru Ono</td>
+    <td>PBSIM2: a simulator for long-read sequencers with a novel generative model of quality scores</td>
+    <td>Bioinformatics (Oxford, England). 2021 May 5;37(5):589-595.</td>
+    <td>32976553</td>
+    <td>doi: 10.1093/bioinformatics/btaa835
+</td>
+</tr>
+<tr>
+    <td>124</td>
+    <td>押木 守</td>
+    <td>Mamoru Oshiki</td>
+    <td>Draft genome sequence of Cytophagales sp. strain WSM2-2, isolated from garden soil</td>
+    <td>Microbiology resource announcements. 2021 Jan 14;10(2):e01238-20.</td>
+    <td>33446590</td>
+    <td>doi: 10.1128/MRA.01238-20
+</td>
+</tr>
+<tr>
+    <td>125</td>
+    <td>西村 瑠佳</td>
+    <td>Luca Nishimura</td>
+    <td>Identification of ancient viruses from metagenomic data of the Jomon people</td>
+    <td>Journal of human genetics. 2021 Mar;66(3):287-296.</td>
+    <td>32994538</td>
+    <td>doi: 10.1038/s10038-020-00841-6
+</td>
+</tr>
+<tr>
+    <td>126</td>
+    <td>宮路 直実</td>
+    <td>Naomi Miyaji</td>
+    <td>The transcriptional response to salicylic acid plays a role in Fusarium yellows resistance in Brassica rapa L</td>
+    <td>Plant cell reports. 2021 Apr;40(4):605-619.</td>
+    <td>33459838</td>
+    <td>doi: 10.1007/s00299-020-02658-1
+</td>
+</tr>
+<tr>
+    <td>127</td>
+    <td>金森 駿介, 河田 雅圭</td>
+    <td>Shunsuke Kanamori, Masakado Kawata</td>
+    <td>Detection of genes positively selected in Cuban Anolis lizards that naturally inhabit hot and open areas, and currently thrive in urban areas</td>
+    <td>Ecology and evolution. 2021 Jan 29;11(4):1719-1728.</td>
+    <td>33613999</td>
+    <td>doi: 10.1002/ece3.7161
+</td>
+</tr>
+<tr>
+    <td>128</td>
+    <td>木村 敦</td>
+    <td>Atsushi P Kimura</td>
+    <td>A dual enhancer-silencer element, DES-K16, in mouse spermatocyte-derived GC-2spd(ts) cells</td>
+    <td>Biochemical and biophysical research communications. 2021 Jan 1;534:1007-1012.</td>
+    <td>33121685</td>
+    <td>doi: 10.1016/j.bbrc.2020.10.049
+</td>
+</tr>
+<tr>
+    <td>129</td>
+    <td>江上 陸, 黒田 真也</td>
+    <td>Riku Egami, Shinya Kuroda</td>
+    <td>Trans-omic analysis reveals obesity-associated dysregulation of inter-organ metabolic cycles between the liver and skeletal muscle</td>
+    <td>iScience. 2021 Feb 20;24(3):102217.</td>
+    <td>33748705</td>
+    <td>doi: 10.1016/j.isci.2021.102217
+</td>
+</tr>
+<tr>
+    <td>130</td>
+    <td>北住 愛</td>
+    <td>Ai Kitazumi</td>
+    <td>Novel and transgressive salinity tolerance in recombinant inbred lines of rice created by physiological coupling-uncoupling and network rewiring effects</td>
+    <td>Frontiers in plant science. 2021 Feb 23;12:615277.</td>
+    <td>33708229</td>
+    <td>doi: 10.3389/fpls.2021.615277
+</td>
+</tr>
+<tr>
+    <td>131</td>
+    <td>平林 茂樹</td>
+    <td>Shigeki Hirabayashi</td>
+    <td>APOBEC3B is preferentially expressed at the G2/M phase of cell cycle</td>
+    <td>Biochemical and biophysical research communications. 2021 Mar 26;546:178-184.</td>
+    <td>33592502</td>
+    <td>doi: 10.1016/j.bbrc.2021.02.008
+</td>
+</tr>
+<tr>
+    <td>132</td>
+    <td>佐藤 健吾</td>
+    <td>Kengo Sato</td>
+    <td>RNA secondary structure prediction using deep learning with thermodynamic integration</td>
+    <td>Nature communications. 2021 Feb 11;12(1):941.</td>
+    <td>33574226</td>
+    <td>doi: 10.1038/s41467-021-21194-4
+</td>
+</tr>
+<tr>
+    <td>133</td>
+    <td>安齋 賢</td>
+    <td>Satoshi Ansai</td>
+    <td>Genome editing reveals fitness effects of a gene for sexual dichromatism in Sulawesian fishes</td>
+    <td>Nature communications. 2021 Mar 1;12(1):1350.</td>
+    <td>33649298</td>
+    <td>doi: 10.1038/s41467-021-21697-0
+</td>
+</tr>
+<tr>
+    <td>134</td>
+    <td>山口 雅也</td>
+    <td>Masaya Yamaguchi</td>
+    <td>Epidemiological analysis of pneumococcal strains isolated at Yangon Children's Hospital in Myanmar via whole-genome sequencing-based methods</td>
+    <td>Microbial genomics. 2021 Feb;7(2):000523.</td>
+    <td>33565958</td>
+    <td>doi: 10.1099/mgen.0.000523
+</td>
+</tr>
+<tr>
+    <td>135</td>
+    <td>井原 邦夫</td>
+    <td>Kunio Ihara</td>
+    <td>Loss of cell wall integrity genes cpxA and mrcB causes flocculation in Escherichia coli</td>
+    <td>The Biochemical journal. 2021 Jan 15;478(1):41-59.</td>
+    <td>33196080</td>
+    <td>doi: 10.1042/BCJ20200723
+</td>
+</tr>
+<tr>
+    <td>136</td>
+    <td>中村 保一</td>
+    <td>Yasukazu Nakamura</td>
+    <td>Complete sequence and structure of the genome of the harmful algal bloom-forming cyanobacterium Planktothrix agardhii NIES-204T and detailed analysis of secondary metabolite gene clusters</td>
+    <td>Harmful algae. 2021 Jan;101:101942.</td>
+    <td>33526179</td>
+    <td>doi: 10.1016/j.hal.2020.101942
+</td>
+</tr>
+<tr>
+    <td>137</td>
+    <td>須崎 大地</td>
+    <td>Daichi Susaki</td>
+    <td>Dynamics of the cell fate specifications during female gametophyte development in Arabidopsis</td>
+    <td>PLoS biology. 2021 Mar 26;19(3):e3001123.</td>
+    <td>33770073</td>
+    <td>doi: 10.1371/journal.pbio.3001123
+</td>
+</tr>
+<tr>
+    <td>138</td>
+    <td>中川 草</td>
+    <td>So Nakagawa</td>
+    <td>Diverse mosquito-specific flaviviruses in the Bolivian Amazon basin</td>
+    <td>The Journal of general virology. 2021 Mar;102(3).</td>
+    <td>33416463</td>
+    <td>doi: 10.1099/jgv.0.001518
+</td>
+</tr>
+<tr>
+    <td>139</td>
+    <td>中川 草</td>
+    <td>So Nakagawa</td>
+    <td>Expression of ERV3-1 in leukocytes of acute myelogenous leukemia patients</td>
+    <td>Gene. 2021 Mar 20;773:145363.</td>
+    <td>33338509</td>
+    <td>doi: 10.1016/j.gene.2020.145363
+</td>
+</tr>
+<tr>
+    <td>140</td>
+    <td>長﨑 正朗</td>
+    <td>Masao Nagasaki</td>
+    <td>Practical guide for managing large-scale human genome data in research</td>
+    <td>Journal of human genetics. 2021 Jan;66(1):39-52.</td>
+    <td>33097812</td>
+    <td>doi: 10.1038/s10038-020-00862-1
+</td>
+</tr>
+<tr>
+    <td>141</td>
+    <td>稲垣 宗一</td>
+    <td>Soichi Inagaki</td>
+    <td>Chromatin-based mechanisms to coordinate convergent overlapping transcription</td>
+    <td>Nature plants. 2021 Mar;7(3):295-302.</td>
+    <td>33649596</td>
+    <td>doi: 10.1038/s41477-021-00868-3
+</td>
+</tr>
+<tr>
+    <td>142</td>
+    <td>吉田 光範</td>
+    <td>Mitsunori Yoshida</td>
+    <td>A Novel DNA Chromatography Method to Discriminate Mycobacterium abscessus Subspecies and Macrolide Susceptibility</td>
+    <td>EBioMedicine. 2021 Feb;64:103187.</td>
+    <td>33446475</td>
+    <td>doi: 10.1016/j.ebiom.2020.103187
+</td>
+</tr>
+<tr>
+    <td>143</td>
+    <td>吉田 光範</td>
+    <td>Mitsunori Yoshida</td>
+    <td>Complete Genome Sequence of Mycobacterium heckeshornense JCM 15655 T, Closely Related to a Pathogenic Nontuberculous Mycobacterial Species, Mycobacterium xenopi</td>
+    <td>Microbiology resource announcements. 2021 Mar 11;10(10):e00020-21.</td>
+    <td>33707319</td>
+    <td>doi: 10.1128/MRA.00020-21
+</td>
+</tr>
+<tr>
+    <td>144</td>
+    <td>千頭 康彦</td>
+    <td>Yasuhiko Chikami</td>
+    <td>Oral RNAi of diap1 results in rapid reduction of damage to potatoes in Henosepilachna vigintioctopunctata</td>
+    <td>Journal of Pest Science volume 94, pages505–515 (2021)</td>
+    <td>NULL</td>
+    <td>doi: 10.1007/s10340-020-01276-w
+</td>
+</tr>
+<tr>
+    <td>145</td>
+    <td>松波 雅俊</td>
+    <td>Masatoshi Matsunami</td>
+    <td>Transcriptomic Changes in Hot Spring Frog Tadpoles (Buergeria otai) in Response to Heat Stress</td>
+    <td>Frontiers in Ecology and Evolution, October 2021, Volume 9, Article 706887, Pages1-9</td>
+    <td>NULL</td>
+    <td>doi: 10.3389/fevo.2021.706887
+</td>
+</tr>
+<tr>
+    <td>146</td>
+    <td>山田 和範, 林 方州</td>
+    <td>Kazunori D YAMADA, Fangzhou LIN</td>
+    <td>Developing a novel recurrent neural network architecture with fewer parameters and good learning performance</td>
+    <td>Interdisciplinary Information Sciences Vol. 27, No. 1 (2021) 25–40</td>
+    <td>NULL</td>
+    <td>doi: 10.4036/iis.2020.R.01
+</td>
+</tr>
+<tr>
+    <td>147</td>
+    <td>安田 仁奈</td>
+    <td>Nina Yasuda</td>
+    <td>Phylogeography of Blue Corals (Genus Heliopora) Across the Indo-West Pacific</td>
+    <td>Frontiers in Marine Science, August 2021, Volume 8, Article 714662</td>
+    <td>NULL</td>
+    <td>doi: 10.3389/fmars.2021.714662
+</td>
+</tr>
+<tr>
+    <td>148</td>
+    <td>佐藤 晋也</td>
+    <td>Shinya Sato</td>
+    <td>Inheritance of spheroid body and plastid in the raphid diatom Epithemia (Bacillariophyta) during sexual reproduction</td>
+    <td>Phycologia, Volume 60, 2021-Issue 3,Pages 265-273</td>
+    <td>NULL</td>
+    <td>doi: 10.1080/00318884.2021.1909399
+</td>
+</tr>
+<tr>
+    <td>149</td>
+    <td>林 方州</td>
+    <td>Fangzhou Lin</td>
+    <td>An Effective Convolutional Neural Network for Visualized Understanding Transboundary Air Pollution Based on Himawari-8 Satellite Images</td>
+    <td>IEEE Geoscience and Remote Sensing Letters ( Volume: 19),13 August 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.1109/LGRS.2021.3102939
+</td>
+</tr>
+<tr>
+    <td>150</td>
+    <td>白石 允梓</td>
+    <td>Masashi Shiraishi</td>
+    <td>Influence of Labor Conditions and Interaction Among Individuals on Circadian Activity Rhythms in the Ant Camponotus Japonicus</td>
+    <td>Journal of Robotics and Mechatronics Vol.33 No.3, 2021, p.582-589</td>
+    <td>NULL</td>
+    <td>doi: 10.20965/jrm.2021.p0582
+</td>
+</tr>
+<tr>
+    <td>151</td>
+    <td>福永 津嵩</td>
+    <td>Tsukasa Fukunaga</td>
+    <td>Mirage: estimation of ancestral gene-copy numbers by considering different evolutionary patterns among gene families</td>
+    <td>Bioinformatics Advances, Volume 1, Issue 1, 2021, 1–10</td>
+    <td>NULL</td>
+    <td>doi: 10.1093/bioadv/vbab014
+</td>
+</tr>
+<tr>
+    <td>152</td>
+    <td>下村 晃一郎</td>
+    <td>Koichiro Shimomura</td>
+    <td>Quantitative trait locus analysis of cucumber fruit texture using double‐digest restriction‐site‐associated DNA sequencing</td>
+    <td>Euphytica volume 217, Article number: 107 (2021)</td>
+    <td>NULL</td>
+    <td>doi: 10.1007/s10681-021-02830-y
+</td>
+</tr>
+<tr>
+    <td>153</td>
+    <td>鳥丸 猛</td>
+    <td>Torimaru Takeshi</td>
+    <td>ヒメアオキの花成関連性遺伝子領域の探索</td>
+    <td>中部森林研究 巻69, p.1-4, 発行日 2021-05-30</td>
+    <td>NULL</td>
+    <td>doi: 10.18999/chufr.69.1
+</td>
+</tr>
+<tr>
+    <td>154</td>
+    <td>鈴木 雅大</td>
+    <td>Masahiro Suzuki</td>
+    <td>A new flattened species of Gracilariopsis (Gracilariales, Rhodophyta) from Japan</td>
+    <td>Phycologia, Volume 60, 2021-Issue 2, 158-163</td>
+    <td>NULL</td>
+    <td>doi: 10.1080/00318884.2021.1880755
+</td>
+</tr>
+<tr>
+    <td>155</td>
+    <td>鈴木 雅大</td>
+    <td>Masahiro Suzuki</td>
+    <td>Morpho-anatomical and molecular reassessments of Rhodymenia prostrata (Rhodymeniaceae, Rhodophyta) from Japan support the recognition of Halopeltis tanakae nom. nov</td>
+    <td>Phycologia, Volume 60, 2021 - Issue 6, Pages 582-588</td>
+    <td>NULL</td>
+    <td>doi: 10.1080/00318884.2021.1959743
+</td>
+</tr>
+<tr>
+    <td>156</td>
+    <td>鈴木 雅大</td>
+    <td>Masahiro Suzuki</td>
+    <td>Fredericqia (Phyllophoraceae, Rhodophyta) in the northwestern Pacific, with the description of Fredericqia chiharae sp. nov.</td>
+    <td>Phycologia, Volume 60, 2021 - Issue 3, Pages 210-214</td>
+    <td>NULL</td>
+    <td>doi: 10.1080/00318884.2021.1892399
+</td>
+</tr>
+<tr>
+    <td>157</td>
+    <td>鈴木 雅大</td>
+    <td>Masahiro Suzuki</td>
+    <td>A new species of the genus Sheathia (Batrachospermaceae, Rhodophyta) from Japan</td>
+    <td>Phycologia, Volume 60, 2021 - Issue 4, Pages 368-374</td>
+    <td>NULL</td>
+    <td>doi: 10.1080/00318884.2021.1946643
+</td>
+</tr>
+<tr>
+    <td>158</td>
+    <td>鈴木 雅大</td>
+    <td>Masahiro Suzuki</td>
+    <td>First record of Sheathia abscondita Stancheva, Sheath & M.L.Vis (Batrachospermaceae, Rhodophyta) from Japan.</td>
+    <td>Bull. Natl. Mus. Nat. Sci., Ser. B, 47(4), pp. 175–182, November 22, 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.50826/bnmnsbot.47.4_175
+</td>
+</tr>
+<tr>
+    <td>159</td>
+    <td>湯山 育子</td>
+    <td>Ikuko Yuyama</td>
+    <td>Application of RNA Interference Technology to Acroporid Juvenile Corals</td>
+    <td>Front. Mar. Sci., 09 August 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.3389/fmars.2021.688876
+</td>
+</tr>
+<tr>
+    <td>160</td>
+    <td>齋藤 裕</td>
+    <td>Yutaka Saito</td>
+    <td>Machine-learning-guided library design cycle for directed evolution of enzymes: the effects of training data composition on sequence space exploration</td>
+    <td>ACS Catal. 2021, 11, 23, 14615–14624</td>
+    <td>NULL</td>
+    <td>doi: 10.1021/acscatal.1c03753
+</td>
+</tr>
+<tr>
+    <td>161</td>
+    <td>佐藤 賢二</td>
+    <td>Kenji Satou</td>
+    <td>Classification of Imbalanced Data Represented as Binary Features</td>
+    <td>Appl. Sci. 2021, 11(17), 7825</td>
+    <td>NULL</td>
+    <td>doi: 10.3390/app11177825
+</td>
+</tr>
+<tr>
+    <td>162</td>
+    <td>下野 嘉子</td>
+    <td>Yoshiko Shimono</td>
+    <td>Revegetation in Japan overlooks geographical genetic structure of native Artemisia indica var. maximowiczii populations</td>
+    <td>Restoration Ecolog 2021</td>
+    <td>NULL</td>
+    <td>doi.org/10.1111/rec.13567
+</td>
+</tr>
+<tr>
+    <td>163</td>
+    <td>神澤 秀明</td>
+    <td>Hideaki Kanzawa-Kiriyama</td>
+    <td>Ancient genomes from the initial Jomon period: new insights into the genetic history of the Japanese archipelago</td>
+    <td>Anthropological Science, Vol. 129(1), 13–22, 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.1537/ase.2012132
+</td>
+</tr>
+<tr>
+    <td>164</td>
+    <td>佐藤 賢二</td>
+    <td>Kenji Satou</td>
+    <td>The Enrichment of Texture Information to Improve Optical Flow for Silhouette Image</td>
+    <td>(IJACSA) International Journal of Advanced Computer Science and Applications, Vol. 12, No. 2, 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.14569/IJACSA.2021.0120253
+</td>
+</tr>
+<tr>
+    <td>165</td>
+    <td>小林 光智衣</td>
+    <td>Michie Kobayashi</td>
+    <td>Insertion of a transposable element in Less Shattering1 (SvLes1) gene is not always involved in foxtail millet (Setaria italica) domestication</td>
+    <td>Genetic Resources and Crop Evolution volume 68, pages 2923–2930 (2021)</td>
+    <td>NULL</td>
+    <td>doi: 10.1007/s10722-021-01165-w
+</td>
+</tr>
+<tr>
+    <td>166</td>
+    <td>坂山 英俊</td>
+    <td>HidetoshiSakayama</td>
+    <td>New distributional records, taxonomy, morphology, and genetic variations of the endangered brackish-water species Lamprothamnium succinctum (Charales, Charophyceae) in Japan</td>
+    <td>Journal of Asia-Pacific Biodiversity, Volume 14, Issue 1, 1 March 2021, Pages 15-22</td>
+    <td>NULL</td>
+    <td>doi: 10.1016/j.japb.2020.09.005
+</td>
+</tr>
+<tr>
+    <td>167</td>
+    <td>毛利 公一, 福永 津嵩</td>
+    <td>Koichi Mori, Tsukasa Fukunaga</td>
+    <td>MotiMul: A significant discriminative sequence motif discovery algorithm with multiple testing correction</td>
+    <td>IEEE, 13 January 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.1109/BIBM49941.2020.9313598</td>
+</tr>
+</table>

--- a/docs/report/report.md
+++ b/docs/report/report.md
@@ -183,51 +183,65 @@ title: "各種統計"
 </table>
 
 
-## 論文数
+## 発行済み査読付き論文数
 
 集計期間：1月1日〜12月31日
 
-※ 原著論文発行済のみを数えることとする
 
 <table>
 <tr>
 	<th width="300">論文雑誌の出版年</th>
-	<th width="300">論文数</th>
+	<th width="300">各年度末更新時に集計した論文数</th>
+	<th width="300">各年度末更新時の後に追加で申請があった論文数</th>
 </tr>
 <tr>
 	<td>2012</td>
 	<td>9</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2013</td>
 	<td>23</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2014</td>
 	<td>53</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2015</td>
 	<td>43</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2016</td>
 	<td>83</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2017</td>
 	<td>93</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2018</td>
 	<td>113</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2019</td>
 	<td>104</td>
+	<td>1</td>
 </tr>
 <tr>
 	<td>2020</td>
 	<td>124</td>
+	<td>1</td>
+</tr>
+<tr>
+	<td>2021</td>
+	<td>167</td>
+	<td>0</td>
 </tr>
 </table>

--- a/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2012.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2012.md
@@ -1,15 +1,17 @@
 ---
 id: papers_2012
-title: Published Papers (2012)
+title: Published Papers(2012)
 ---
 
-List of papers published by users between 2012.01.01 -- 2012.12.31.
+## List of papers published by users between 2012.01.01 -- 2012.12.31.
+
+### Papers compiled at the end-of-year renewal in 2021
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2013.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2013.md
@@ -3,13 +3,15 @@ id: papers_2013
 title: Published Papers(2013)
 ---
 
-List of papers published by users between 2013.01.01 -- 2013.12.31.
+## List of papers published by users between 2013.01.01 -- 2013.12.31.
+
+### Papers compiled at the end-of-year renewal in 2013
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2014.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2014.md
@@ -3,13 +3,15 @@ id: papers_2014
 title: Published Papers(2014)
 ---
 
-List of papers published by users between 2014.01.01 -- 2014.12.31.
+## List of papers published by users between 2014.01.01 -- 2014.12.31.
+
+### Papers compiled at the end-of-year renewal in 2014
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2015.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2015.md
@@ -3,13 +3,15 @@ id: papers_2015
 title: Published Papers(2015)
 ---
 
-List of papers published by users between 2015.01.01 -- 2015.12.31.
+## List of papers published by users between 2015.01.01 -- 2015.12.31.
+
+### Papers compiled at the end-of-year renewal in 2015
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2016.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2016.md
@@ -3,13 +3,15 @@ id: papers_2016
 title: Published Papers(2016)
 ---
 
-List of papers published by users between 2016.01.01 -- 2016.12.31.
+## List of papers published by users between 2016.01.01 -- 2016.12.31.
+
+### Papers compiled at the end-of-year renewal in 2016
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2017.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2017.md
@@ -3,13 +3,15 @@ id: papers_2017
 title: Published Papers(2017)
 ---
 
-List of papers published by users between 2017.01.01 -- 2017.12.31.
+## List of papers published by users between 2017.01.01 -- 2017.12.31.
+
+### Papers compiled at the end-of-year renewal in 2017
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2018.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2018.md
@@ -3,13 +3,15 @@ id: papers_2018
 title: Published Papers(2018)
 ---
 
-List of papers published by users between 2018.01.01 -- 2018.12.31.
+## List of papers published by users between 2018.01.01 -- 2018.12.31.
+
+### Papers compiled at the end-of-year renewal in 2018
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>

--- a/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2019.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2019.md
@@ -1,15 +1,17 @@
 ---
 id: papers_2019
-title: Published Papers (2019)
+title: Published Papers(2019)
 ---
 
-List of papers published by users between 2019.01.01 -- 2019.12.31.
+## List of papers published by users between 2019.01.01 -- 2019.12.31.
+
+### Papers compiled at the end-of-year renewal in 2019
 
 <table>
 <tr>
     <td></td>
-    <td width="150">Authors (Japanese)</td>
-    <td>Authors</td>
+    <td width="150">Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>
@@ -953,5 +955,28 @@ ted with Lotus japonicus in Natural Environments</td>
 	<td>Cell Reports Volume 26, Issue 9, 26 February 2019, Pages 2274-2281.e5</td>
 	<td>NULL</td>
 	<td>doi.org/10.1016/j.celrep.2019.01.109</td>
+</tr>
+</table>
+
+### Additional papers submitted after the end-of-year renewal in 2019.
+
+<table>
+<tr>
+    <td></td>
+    <td width="150">Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
+    <td>Title</td>
+    <td>Journal, Volume, Number, Pages</td>
+    <td>PMID</td>
+    <td>DOI</td>
+</tr>
+<tr>
+    <td>1</td>
+    <td>Yassouf Mhd Yousuf</td>
+    <td>M Yousuf Yassouf</td>
+    <td>Compliance with Deferoxamine Therapy and Thyroid Dysfunction of Patients with β-Thalassemia Major in Syria</td>
+    <td>Hemoglobin. 2019 May;43(3):218-221.</td>
+    <td>31373517</td>
+    <td>doi: 10.1080/03630269.2019.1639517</td>
 </tr>
 </table>

--- a/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2020.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2020.md
@@ -1,15 +1,17 @@
 ---
 id: papers_2020
-title: Published Papers (2020)
+title: Published Papers(2020)
 ---
 
-List of papers published by users between 2020.01.01 -- 2020.12.31.
+## List of papers published by users between 2020.01.01 -- 2020.12.31.
+
+### Papers compiled at the end-of-year renewal in 2020
 
 <table>
 <tr>
     <td></td>
-    <td>Authors (Japanese)</td>
-    <td>Authors</td>
+    <td>Supercomputer users in authors list (Japanese)</td>
+    <td>Supercomputer users in authors list</td>
     <td>Title</td>
     <td>Journal, Volume, Number, Pages</td>
     <td>PMID</td>
@@ -1133,5 +1135,31 @@ e in Japanese gentian with the CRISPR/Cas9 system</td>
 	<td>Insect Sci. 2020 Apr;27(2):202-211.</td>
 	<td>30203565</td>
 	<td>doi: 10.1111/1744-7917.12640.</td>
+</tr>
+</table>
+
+
+### Additional papers submitted after the end-of-year renewal in 2020
+
+<table>
+<tr>
+    <td></td>
+    <td>Supercomputer users in authors list(Japanese)</td>
+    <td>Supercomputer users in authors list</td>
+    <td>Title</td>
+    <td>Journal, Volume, Number, Pages</td>
+    <td>PMID</td>
+    <td>DOI</td>
+    <td>
+</td>
+</tr>
+<tr>
+    <td>1</td>
+    <td>鈴木 郁夫</td>
+    <td>Ikuo K Suzuki</td>
+    <td>Molecular drivers of human cerebral cortical evolution</td>
+    <td>Neuroscience research. 2020 Feb;151:1-14.</td>
+    <td>31175883</td>
+    <td>doi: 10.1016/j.neures.2019.05.007</td>
 </tr>
 </table>

--- a/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2021.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/report/papers_2021.md
@@ -1,0 +1,1691 @@
+---
+id: papers_2021
+title: Published Papers(2021)
+---
+
+
+## List of papers published by users between 2021.01.01 -- 2021.12.31.
+
+### Papers compiled at the end-of-year renewal in 2021
+
+<table>
+<tr>
+    <td></td>
+    <td>Supercomputer users in authors list(Japanese)</td>
+    <td>Supercomputer users in authors list</td>
+    <td>Title</td>
+    <td>Journal, Volume, Number, Pages</td>
+    <td>PMID</td>
+    <td>DOI
+</td>
+</tr>
+<tr>
+    <td>1</td>
+    <td>石橋 知彦</td>
+    <td>Tomohiko Ishibashi</td>
+    <td>Aryl hydrocarbon receptor is essential for the pathogenesis of pulmonary arterial hypertension</td>
+    <td>Proc Natl Acad Sci U S A. 2021 Mar 16;118(11):e2023899118.</td>
+    <td>33836606</td>
+    <td>doi: 10.1073/pnas.2023899118.
+</td>
+</tr>
+<tr>
+    <td>2</td>
+    <td>平瀬 祥太朗, 岩崎 渉</td>
+    <td>Shotaro Hirase, Wataru Iwasaki</td>
+    <td>Integrative genomic phylogeography reveals signs of mitonuclear incompatibility in a natural hybrid goby population</td>
+    <td>Evolution. 2021 Jan;75(1):176-194.</td>
+    <td>33165944</td>
+    <td>doi: 10.1111/evo.14120. 
+</td>
+</tr>
+<tr>
+    <td>3</td>
+    <td>Ravinet Mark, 石川 麻乃</td>
+    <td>Mark Ravinet,Asano Ishikawa</td>
+    <td>Patterns of genomic divergence and introgression between Japanese sticklebackspecies with overlapping breeding habitats.</td>
+    <td>J Evol Biol. 2021 Jan;34(1):114-127. </td>
+    <td>32557887</td>
+    <td>doi: 10.1111/jeb.13664.
+</td>
+</tr>
+<tr>
+    <td>4</td>
+    <td>西原 昌宏</td>
+    <td>Masahiro Nishihara</td>
+    <td>Identification and characterization of xanthone biosynthetic genes contributing to the vivid red coloration of red-flowered gentian</td>
+    <td>The Plant journal : for cell and molecular biology. 2021 Sep;107(6):1711-1723.</td>
+    <td>34245606</td>
+    <td>doi: 10.1111/tpj.15412
+</td>
+</tr>
+<tr>
+    <td>5</td>
+    <td>齋藤 裕</td>
+    <td>Yutaka Saito</td>
+    <td>Evotuning protocols for Transformer-based variant effect prediction on multi-domain proteins</td>
+    <td>Briefings in bioinformatics. 2021 Nov 5;22(6):bbab234.</td>
+    <td>34180966</td>
+    <td>doi: 10.1093/bib/bbab234
+</td>
+</tr>
+<tr>
+    <td>6</td>
+    <td>江副 晃洋</td>
+    <td>Akihiro Ezoe</td>
+    <td>Degree of Functional Divergence in Duplicates Is Associated with Distinct Roles in Plant Evolution</td>
+    <td>Molecular biology and evolution. 2021 Apr 13;38(4):1447-1459.</td>
+    <td>33290522</td>
+    <td>doi: 10.1093/molbev/msaa302
+</td>
+</tr>
+<tr>
+    <td>7</td>
+    <td>安井 康夫</td>
+    <td>Yasuo Yasui</td>
+    <td>Targeted amplicon sequencing + next-generation sequencing–based bulked segregant analysis identified genetic loci associated with preharvest sprouting tolerance in common buckwheat (Fagopyrum esculentum)</td>
+    <td>BMC plant biology. 2021 Jan 6;21(1):18.</td>
+    <td>33407135</td>
+    <td>doi: 10.1186/s12870-020-02790-w
+</td>
+</tr>
+<tr>
+    <td>8</td>
+    <td>鈴木 啓道</td>
+    <td>Hiromichi Suzuki</td>
+    <td>The transcriptional landscape of Shh medulloblastoma</td>
+    <td>Nature communications. 2021 Mar 19;12(1):1749.</td>
+    <td>33741928</td>
+    <td>doi: 10.1038/s41467-021-21883-0
+</td>
+</tr>
+<tr>
+    <td>9</td>
+    <td>鈴木 郁夫</td>
+    <td>Ikuo K Suzuki</td>
+    <td>1q21.1 distal copy number variants are associated with cerebral and cognitive alterations in humans</td>
+    <td>Translational psychiatry. 2021 Mar 22;11(1):182.</td>
+    <td>33753722</td>
+    <td>doi: 10.1038/s41398-021-01213-0
+</td>
+</tr>
+<tr>
+    <td>10</td>
+    <td>齋藤 裕</td>
+    <td>Yutaka Saito</td>
+    <td>Rational thermostabilisation of four-helix bundle dimeric de novo proteins</td>
+    <td>Scientific reports. 2021 Apr 6;11(1):7526.</td>
+    <td>33824364</td>
+    <td>doi: 10.1038/s41598-021-86952-2
+</td>
+</tr>
+<tr>
+    <td>11</td>
+    <td>齋藤 裕</td>
+    <td>Yutaka Saito</td>
+    <td>Comparative analysis of the relationship between translation efficiency and sequence features of endogenous proteins in multiple organisms</td>
+    <td>Genomics. 2021 Jul;113(4):2675-2682.</td>
+    <td>34058272</td>
+    <td>doi: 10.1016/j.ygeno.2021.05.037
+</td>
+</tr>
+<tr>
+    <td>12</td>
+    <td>山口 暢俊, 稲垣 宗一</td>
+    <td>Nobutoshi Yamaguchi, Soichi Inagaki</td>
+    <td>H3K27me3 demethylases alter HSP22 and HSP17.6C expression in response to recurring heat in Arabidopsis</td>
+    <td>Nature communications. 2021 Jun 9;12(1):3480.</td>
+    <td>34108473</td>
+    <td>doi: 10.1038/s41467-021-23766-w
+</td>
+</tr>
+<tr>
+    <td>13</td>
+    <td>村越 祐美, 高尾 祥丈</td>
+    <td>Yumi Murakoshi, Yoshitake Takao</td>
+    <td>Draft Genome Sequence of Sicyoidochytrium minutum DNA Virus Strain 001</td>
+    <td>Microbiology resource announcements. 2021 Jun 10;10(23):e0041821.</td>
+    <td>34110234</td>
+    <td>doi: 10.1128/MRA.00418-21
+</td>
+</tr>
+<tr>
+    <td>14</td>
+    <td>小野寺 康之</td>
+    <td>Yasuyuki Onodera </td>
+    <td>A spinach genome assembly with remarkable completeness, and its use for rapid identification of candidate genes for agronomic traits</td>
+    <td>DNA research : an international journal for rapid publication of reports on genes and genomes. 2021 Jun 25;28(3):dsab004.</td>
+    <td>34142133</td>
+    <td>doi: 10.1093/dnares/dsab004
+</td>
+</tr>
+<tr>
+    <td>15</td>
+    <td>宮原 平</td>
+    <td>Taira Miyahara</td>
+    <td>Effect of Transgenic Rootstock Grafting on the Omics Profiles in Tomato</td>
+    <td>Food safety (Tokyo, Japan). 2021 Jun 25;9(2):32-47.</td>
+    <td>34249588</td>
+    <td>doi: 10.14252/foodsafetyfscj.D-20-00032
+</td>
+</tr>
+<tr>
+    <td>16</td>
+    <td>齋藤 裕</td>
+    <td>Yutaka Saito</td>
+    <td>Machine learning approach for discrimination of genotypes based on bright-field cellular images</td>
+    <td>NPJ systems biology and applications. 2021 Jul 21;7(1):31.</td>
+    <td>34290253</td>
+    <td>doi: 10.1038/s41540-021-00190-w
+</td>
+</tr>
+<tr>
+    <td>17</td>
+    <td>瀬川 高弘</td>
+    <td>Takahiro Segawa</td>
+    <td>Spatial and Temporal Variations in Pigment and Species Compositions of Snow Algae on Mt. Tateyama in Toyama Prefecture, Japan</td>
+    <td>Frontiers in plant science. 2021 Jul 5;12:689119.</td>
+    <td>34290725</td>
+    <td>doi: 10.3389/fpls.2021.689119
+</td>
+</tr>
+<tr>
+    <td>18</td>
+    <td>平瀬 祥太朗</td>
+    <td>Shotaro Hirase</td>
+    <td>Genomic Evidence for Speciation with Gene Flow in Broadcast Spawning Marine Invertebrates</td>
+    <td>Molecular biology and evolution. 2021 Oct 27;38(11):4683-4699.</td>
+    <td>34311468</td>
+    <td>doi: 10.1093/molbev/msab194
+</td>
+</tr>
+<tr>
+    <td>19</td>
+    <td>松波 雅俊</td>
+    <td>Masatoshi Matsunami</td>
+    <td>Coevolution between MHC class I and Antigen Processing Genes in salamanders.</td>
+    <td>Molecular biology and evolution. 2021 Oct 27;38(11):5092-5106.</td>
+    <td>34375431</td>
+    <td>doi: 10.1093/molbev/msab237
+</td>
+</tr>
+<tr>
+    <td>20</td>
+    <td>高橋 鉄美</td>
+    <td>Tetsumi Takahashi</td>
+    <td>Mapping of quantitative trait loci underlying a magic trait in ongoing ecological speciation</td>
+    <td>BMC genomics. 2021 Aug 12;22(1):615.</td>
+    <td>34384356</td>
+    <td>doi: 10.1186/s12864-021-07908-4
+</td>
+</tr>
+<tr>
+    <td>21</td>
+    <td>瀬川 高弘, 西原 秀典</td>
+    <td>Takahiro Segawa, Hidenori Nishihara</td>
+    <td>Ancient DNA reveals multiple origins and migration waves of extinct Japanese brown bear lineages</td>
+    <td>Royal Society open science. 2021 Aug 4;8(8):210518.</td>
+    <td>34386259</td>
+    <td>doi: 10.1098/rsos.210518
+</td>
+</tr>
+<tr>
+    <td>22</td>
+    <td>川崎 純菜, 堀江 真行</td>
+    <td>Junna Kawasaki, Masayuki Horie</td>
+    <td>Hidden Viral Sequences in Public Sequencing Data and Warning for Future Emerging Diseases</td>
+    <td>mBio. 2021 Aug 31;12(4):e0163821.</td>
+    <td>34399612</td>
+    <td>doi: 10.1128/mBio.01638-21
+</td>
+</tr>
+<tr>
+    <td>23</td>
+    <td>草間 和哉</td>
+    <td>Kazuya Kusama </td>
+    <td>The effect of bta-miR-26b in intrauterine extracellular vesicles on maternal immune system during the implantation period</td>
+    <td>Biochemical and biophysical research communications. 2021 Oct 8;573:100-106.</td>
+    <td>34403805</td>
+    <td>doi: 10.1016/j.bbrc.2021.08.019
+</td>
+</tr>
+<tr>
+    <td>24</td>
+    <td>松前 ひろみ</td>
+    <td>Hiromi Matsumae</td>
+    <td>Exploring correlations in genetic and cultural variation across language families in Northeast Asia</td>
+    <td>Science advances. 2021 Aug 18;7(34):eabd9223.</td>
+    <td>34407936</td>
+    <td>doi: 10.1126/sciadv.abd9223
+</td>
+</tr>
+<tr>
+    <td>25</td>
+    <td>石川 麻乃</td>
+    <td>Asano Ishikawa</td>
+    <td>The effect of bta-miR-26b in intrauterine extracellular vesicles on maternal immune system during the implantation period</td>
+    <td>Biology letters. 2021 Aug;17(8):20210204.</td>
+    <td>34428959</td>
+    <td>doi: 10.1098/rsbl.2021.0204
+</td>
+</tr>
+<tr>
+    <td>26</td>
+    <td>湯山 育子</td>
+    <td>Ikuko Yuyama</td>
+    <td>Transcriptome Analysis of Durusdinium Associated with the Transition from Free-Living to Symbiotic</td>
+    <td>Microorganisms. 2021 Jul 22;9(8):1560.</td>
+    <td>34442639</td>
+    <td>doi: 10.3390/microorganisms9081560
+</td>
+</tr>
+<tr>
+    <td>27</td>
+    <td>前野 慎太朗, 谷澤 靖洋, 遠藤 明仁</td>
+    <td>Shintaro Maeno, Yasuhiro Tanizawa, Akihito Endo</td>
+    <td>Oligosaccharide Metabolism and Lipoteichoic Acid Production in Lactobacillus gasseri and Lactobacillus paragasseri</td>
+    <td>Microorganisms. 2021 Jul 26;9(8):1590.</td>
+    <td>34442669</td>
+    <td>doi: 10.3390/microorganisms9081590
+</td>
+</tr>
+<tr>
+    <td>28</td>
+    <td>門田 有希</td>
+    <td>Yuki Monden</td>
+    <td>Transcriptome Analysis Reveals Key Genes Involved in Weevil Resistance in the Hexaploid Sweetpotato</td>
+    <td>Plants (Basel, Switzerland). 2021 Jul 27;10(8):1535.</td>
+    <td>34451581</td>
+    <td>doi: 10.3390/plants10081535
+</td>
+</tr>
+<tr>
+    <td>29</td>
+    <td>向笠 勝貴</td>
+    <td>Katsuki Mukaigasa</td>
+    <td>The developmental hourglass model is applicable to the spinal cord based on single-cell transcriptomes and non-conserved cis-regulatory elements</td>
+    <td>Development, growth &amp; differentiation. 2021 Sep;63(7):372-391.</td>
+    <td>34473348</td>
+    <td>doi: 10.1111/dgd.12750
+</td>
+</tr>
+<tr>
+    <td>30</td>
+    <td>松井 求</td>
+    <td>Motomu Matsui</td>
+    <td>Machine learning-assisted single-cell Raman fingerprinting for in situ and nondestructive classification of prokaryotes</td>
+    <td>iScience. 2021 Aug 11;24(9):102975.</td>
+    <td>34485857</td>
+    <td>doi: 10.1016/j.isci.2021.102975
+</td>
+</tr>
+<tr>
+    <td>31</td>
+    <td>加藤 有己</td>
+    <td>Yuki Kato</td>
+    <td>Mutations in the adenosine deaminase ADAR1 that prevent endogenous Z-RNA editing induce Aicardi-Goutieres syndrome-like encephalopathy</td>
+    <td>Immunity. 2021 Sep 14;54(9):1976-1988.e7.</td>
+    <td>34525338</td>
+    <td>doi: 10.1016/j.immuni.2021.08.022
+</td>
+</tr>
+<tr>
+    <td>32</td>
+    <td>松波 雅俊</td>
+    <td>Masatoshi Matsunami </td>
+    <td>Species divergence and repeated ancient hybridization in a Sulawesian lake system</td>
+    <td>Journal of evolutionary biology. 2021 Nov;34(11):1767-1780.</td>
+    <td>34532915</td>
+    <td>doi: 10.1111/jeb.13932
+</td>
+</tr>
+<tr>
+    <td>33</td>
+    <td>井原 邦夫</td>
+    <td>Kunio Ihara</td>
+    <td>Identification of ksg1 mutation showing long-lived phenotype in fission yeast</td>
+    <td>Genes to cells : devoted to molecular &amp; cellular mechanisms. 2021 Dec;26(12):967-978.</td>
+    <td>34534388</td>
+    <td>doi: 10.1111/gtc.12897
+</td>
+</tr>
+<tr>
+    <td>34</td>
+    <td>一色 真理子</td>
+    <td>Mariko Isshiki</td>
+    <td>Admixture with indigenous people helps local adaptation: admixture-enabled selection in Polynesians</td>
+    <td>BMC ecology and evolution. 2021 Sep 22;21(1):179.</td>
+    <td>34551727</td>
+    <td>doi: 10.1186/s12862-021-01900-y
+</td>
+</tr>
+<tr>
+    <td>35</td>
+    <td>西原 秀典</td>
+    <td>Hidenori Nishihara</td>
+    <td>Replacement of owl monkey centromere satellite by a newly evolved variant was a recent and rapid process</td>
+    <td>Genes to cells : devoted to molecular &amp; cellular mechanisms. 2021 Dec;26(12):979-986.</td>
+    <td>34570411</td>
+    <td>doi: 10.1111/gtc.12898
+</td>
+</tr>
+<tr>
+    <td>36</td>
+    <td>草間 和哉, 吉田 佳乃子</td>
+    <td>Kazuya Kusama, Kanoko Yoshida</td>
+    <td>PGE2 and Thrombin Induce Myofibroblast Transdifferentiation via Activin A and CTGF in Endometrial Stromal Cells</td>
+    <td>Endocrinology. 2021 Dec 1;162(12):bqab207.</td>
+    <td>34606582</td>
+    <td>doi: 10.1210/endocr/bqab207
+</td>
+</tr>
+<tr>
+    <td>37</td>
+    <td>小林 正樹</td>
+    <td>Masaki J Kobayashi</td>
+    <td>The genome of Shorea leprosula (Dipterocarpaceae) highlights the ecological relevance of drought in aseasonal tropical rainforests</td>
+    <td>Communications biology. 2021 Oct 7;4(1):1166.</td>
+    <td>34620991</td>
+    <td>doi: 10.1038/s42003-021-02682-1
+</td>
+</tr>
+<tr>
+    <td>38</td>
+    <td>浜口 悠</td>
+    <td>Yu Hamaguchi</td>
+    <td>Impact of human gene annotations on RNA-seq differential expression analysis</td>
+    <td>BMC genomics. 2021 Oct 8;22(1):730.</td>
+    <td>34625021</td>
+    <td>doi: 10.1186/s12864-021-08038-7
+</td>
+</tr>
+<tr>
+    <td>39</td>
+    <td>植松 真章</td>
+    <td>Masaaki Uematsu</td>
+    <td>Raman microscopy-based quantification of the physical properties of intracellular lipids</td>
+    <td>Communications biology. 2021 Oct 8;4(1):1176.</td>
+    <td>34625633</td>
+    <td>doi: 10.1038/s42003-021-02679-w
+</td>
+</tr>
+<tr>
+    <td>40</td>
+    <td>佐藤 綾</td>
+    <td>Aya Satoh</td>
+    <td>De novo assembly and annotation of the mangrove cricket genome</td>
+    <td>BMC research notes. 2021 Oct 9;14(1):387.</td>
+    <td>34627387</td>
+    <td>doi: 10.1186/s13104-021-05798-z
+</td>
+</tr>
+<tr>
+    <td>41</td>
+    <td>山﨑 曜</td>
+    <td>Yo Y Yamasaki</td>
+    <td>Gudgeon fish with and without genetically determined countershading coexist in heterogeneous littoral environments of an ancient lake</td>
+    <td>Ecology and evolution. 2021 Aug 31;11(19):13283-13294.</td>
+    <td>34646469</td>
+    <td>doi: 10.1002/ece3.8050
+</td>
+</tr>
+<tr>
+    <td>42</td>
+    <td>杉本 竜太</td>
+    <td>Ryota Sugimoto</td>
+    <td>Comprehensive discovery of CRISPR-targeted terminally redundant sequences in the human gut metagenome: Viruses, plasmids, and more</td>
+    <td>PLoS computational biology. 2021 Oct 21;17(10):e1009428.</td>
+    <td>34673779</td>
+    <td>doi: 10.1371/journal.pcbi.1009428
+</td>
+</tr>
+<tr>
+    <td>43</td>
+    <td>中村 保一</td>
+    <td>Yasukazu Nakamura</td>
+    <td>Genome sequencing of the NIES Cyanobacteria collection with a focus on the heterocyst-forming clade.</td>
+    <td>DNA research : an international journal for rapid publication of reports on genes and genomes. 2021 Oct 11;28(6):dsab024.</td>
+    <td>34677568</td>
+    <td>doi: 10.1093/dnares/dsab024
+</td>
+</tr>
+<tr>
+    <td>44</td>
+    <td>安河内 彦輝</td>
+    <td>Yoshiki Yasukochi </td>
+    <td>Upregulation of cathepsin L gene under mild cold conditions in young Japanese male adults</td>
+    <td>Journal of physiological anthropology. 2021 Oct 22;40(1):16.</td>
+    <td>34686211</td>
+    <td>doi: 10.1186/s40101-021-00267-9
+</td>
+</tr>
+<tr>
+    <td>45</td>
+    <td>谷澤 靖洋, 矢倉 勝, 中村 保一</td>
+    <td>Yasuhiro Tanizawa, Masaru Yagura, Yasukazu Nakamura</td>
+    <td>Identification of the sex-determining factor in the liverwort Marchantia polymorpha reveals unique evolution of sex chromosomes in a haploid system.</td>
+    <td>Current biology : CB. 2021 Dec 20;31(24):5522-5532.e7.</td>
+    <td>34735792</td>
+    <td>doi: 10.1016/j.cub.2021.10.023
+</td>
+</tr>
+<tr>
+    <td>46</td>
+    <td>宮澤 清太</td>
+    <td>Seita Miyazawa</td>
+    <td>Studies of Turing pattern formation in zebrafish skin</td>
+    <td>Philosophical transactions. Series A, Mathematical, physical, and engineering sciences. 2021 Dec 27;379(2213):20200274.</td>
+    <td>34743596</td>
+    <td>doi: 10.1098/rsta.2020.0274
+</td>
+</tr>
+<tr>
+    <td>47</td>
+    <td>谷澤 靖洋, 遠野 雅徳</td>
+    <td>Yasuhiro Tanizawa, Masanori Tohno</td>
+    <td>Clostridium zeae sp. nov., isolated from corn silage</td>
+    <td>International journal of systematic and evolutionary microbiology. 2021 Nov;71(11).</td>
+    <td>34748474</td>
+    <td>doi: 10.1099/ijsem.0.005088
+</td>
+</tr>
+<tr>
+    <td>48</td>
+    <td>中川 草</td>
+    <td>So Nakagawa</td>
+    <td>An ancient retroviral RNA element hidden in mammalian genomes and its involvement in co-opted retroviral gene regulation</td>
+    <td>Retrovirology. 2021 Nov 10;18(1):36.</td>
+    <td>34753509</td>
+    <td>doi: 10.1186/s12977-021-00580-2
+</td>
+</tr>
+<tr>
+    <td>49</td>
+    <td>Evariste Tshibangu-Kabamba</td>
+    <td>Evariste Tshibangu-Kabamba </td>
+    <td>High-Resolution Linear Epitope Mapping of the Receptor Binding Domain of SARS-CoV-2 Spike Protein in COVID-19 mRNA Vaccine Recipients</td>
+    <td>Microbiology spectrum. 2021 Dec 22;9(3):e0096521.</td>
+    <td>34756082</td>
+    <td>doi: 10.1128/Spectrum.00965-21
+</td>
+</tr>
+<tr>
+    <td>50</td>
+    <td>神澤 秀明</td>
+    <td>Hideaki Kanzawa-Kiriyama</td>
+    <td>Triangulation supports agricultural spread of the Transeurasian languages</td>
+    <td>Nature. 2021 Nov;599(7886):616-621.</td>
+    <td>34759322</td>
+    <td>doi: 10.1038/s41586-021-04108-8
+</td>
+</tr>
+<tr>
+    <td>51</td>
+    <td>中尾 亮</td>
+    <td>Ryo Nakao</td>
+    <td>Complete Genome Sequence of Leptospira kobayashii Strain E30, Isolated from Soil in Japan</td>
+    <td>Microbiology resource announcements. 2021 Nov 11;10(45):e0090721.</td>
+    <td>34761960</td>
+    <td>doi: 10.1128/MRA.00907-21
+</td>
+</tr>
+<tr>
+    <td>52</td>
+    <td>加藤 有己</td>
+    <td>Yuki Kato </td>
+    <td>An Aicardi-Goutieres syndrome-causative point mutation in Adar1 gene invokes multi-organ inflammation and late-onset encephalopathy in mice</td>
+    <td>Journal of immunology (Baltimore, Md. : 1950). 2021 Dec 15;207(12):3016-3027.</td>
+    <td>34772697</td>
+    <td>doi: 10.4049/jimmunol.2100526
+</td>
+</tr>
+<tr>
+    <td>53</td>
+    <td>津田 勝利</td>
+    <td>Katsutoshi Tsuda</td>
+    <td>Collection, preservation and distribution of Oryza genetic resources by the National Bioresource Project RICE (NBRP-RICE)</td>
+    <td>Breeding science. 2021 Jun;71(3):291-298.</td>
+    <td>34776736</td>
+    <td>doi: 10.1270/jsbbs.21005
+</td>
+</tr>
+<tr>
+    <td>54</td>
+    <td>下村 晃一郎</td>
+    <td>Koichiro Shimomura</td>
+    <td>Identification of quantitative trait loci for powdery mildew resistance in highly resistant cucumber (Cucumis sativus L.) using ddRAD-seq analysis</td>
+    <td>Breeding science. 2021 Jun;71(3):326-333.</td>
+    <td>34776739</td>
+    <td>doi: 10.1270/jsbbs.20141
+</td>
+</tr>
+<tr>
+    <td>55</td>
+    <td>趙 世涛</td>
+    <td>Shitao Zhao</td>
+    <td>Multi-resBind: a residual network-based multi-label classifier for in vivo RNA binding prediction and preference visualization</td>
+    <td>BMC bioinformatics. 2021 Nov 15;22(1):554.</td>
+    <td>34781902</td>
+    <td>doi: 10.1186/s12859-021-04430-y
+</td>
+</tr>
+<tr>
+    <td>56</td>
+    <td>美世 一守</td>
+    <td>Kazumori Mise</td>
+    <td>Undervalued Pseudo-nifH Sequences in Public Databases Distort Metagenomic Insights into Biological Nitrogen Fixers</td>
+    <td>mSphere. 2021 Dec 22;6(6):e0078521.</td>
+    <td>34787447</td>
+    <td>doi: 10.1128/msphere.00785-21
+</td>
+</tr>
+<tr>
+    <td>57</td>
+    <td>水口 洋平, 豊田 敦</td>
+    <td>Yohei Minakuchi, Atsushi Toyoda</td>
+    <td>Genome sequencing of the multicellular alga Astrephomene provides insights into convergent evolution of germ-soma differentiation</td>
+    <td>Scientific reports. 2021 Nov 22;11(1):22231.</td>
+    <td>34811380</td>
+    <td>doi: 10.1038/s41598-021-01521-x
+</td>
+</tr>
+<tr>
+    <td>58</td>
+    <td>川本 麻祐子, 河田 雅圭</td>
+    <td>Mayuko Kawamoto, Masakado Kawata</td>
+    <td>Genetic basis of orange spot formation in the guppy (Poecilia reticulata)</td>
+    <td>BMC ecology and evolution. 2021 Nov 25;21(1):211.</td>
+    <td>34823475</td>
+    <td>doi: 10.1186/s12862-021-01942-2
+</td>
+</tr>
+<tr>
+    <td>59</td>
+    <td>佐藤 健吾</td>
+    <td>Kengo Sato</td>
+    <td>A Max-Margin Model for Predicting Residue-Base Contacts in Protein-RNA Interactions</td>
+    <td>Life (Basel, Switzerland). 2021 Oct 25;11(11):1135.</td>
+    <td>34833011</td>
+    <td>doi: 10.3390/life11111135
+</td>
+</tr>
+<tr>
+    <td>60</td>
+    <td>Vo Phuoc Tuan, 矢原 耕史</td>
+    <td>Vo Phuoc Tuan, Koji Yahara</td>
+    <td>Genome-wide association study of gastric cancer- and duodenal ulcer-derived Helicobacter pylori strains reveals discriminatory genetic variations and novel oncoprotein candidates</td>
+    <td>Microbial genomics. 2021 Nov;7(11):000680.</td>
+    <td>34846284</td>
+    <td>doi: 10.1099/mgen.0.000680
+</td>
+</tr>
+<tr>
+    <td>61</td>
+    <td>有泉 亨</td>
+    <td>Tohru Ariizumi</td>
+    <td>Organelle genome assembly uncovers the dynamic genome reorganization and cytoplasmic male sterility associated genes in tomato</td>
+    <td>Horticulture research. 2021 Dec 1;8(1):250.</td>
+    <td>34848681</td>
+    <td>doi: 10.1038/s41438-021-00676-y
+</td>
+</tr>
+<tr>
+    <td>62</td>
+    <td>渡邊 美穂</td>
+    <td>Miho Watanabe</td>
+    <td>Mariniplasma anaerobium gen. nov., sp. nov., a novel anaerobic marine mollicute, and proposal of three novel genera to reclassify members of Acholeplasma clusters II-IV</td>
+    <td>International journal of systematic and evolutionary microbiology. 2021 Dec;71(12).</td>
+    <td>34874244</td>
+    <td>doi: 10.1099/ijsem.0.005138
+</td>
+</tr>
+<tr>
+    <td>63</td>
+    <td>新里 宙也</td>
+    <td>Chuya Shinzato</td>
+    <td>Whole-Genome Sequencing Highlights Conservative Genomic Strategies of a Stress-Tolerant, Long-Lived Scleractinian Coral, Porites australiensis Vaughan, 1918</td>
+    <td>Genome biology and evolution. 2021 Dec 1;13(12):evab270.</td>
+    <td>34878117</td>
+    <td>doi: 10.1093/gbe/evab270
+</td>
+</tr>
+<tr>
+    <td>64</td>
+    <td>遠野 雅徳, 谷澤 靖洋</td>
+    <td>Masanori Tohno, Yasuhiro Tanizawa</td>
+    <td>Lentilactobacillus fungorum sp. nov., isolated from spent mushroom substrates</td>
+    <td>International journal of systematic and evolutionary microbiology. 2021 Dec;71(12).</td>
+    <td>34913426</td>
+    <td>doi: 10.1099/ijsem.0.005184
+</td>
+</tr>
+<tr>
+    <td>65</td>
+    <td>大島 一里</td>
+    <td>Kazusato Ohshima </td>
+    <td>Genomic Epidemiology and Evolution of Scallion Mosaic Potyvirus From Asymptomatic Wild Japanese Garlic</td>
+    <td>Frontiers in microbiology. 2021 Dec 8;12:789596.</td>
+    <td>34956155</td>
+    <td>doi: 10.3389/fmicb.2021.789596
+</td>
+</tr>
+<tr>
+    <td>66</td>
+    <td>武藤 吉徳</td>
+    <td>Yoshinori Muto</td>
+    <td>Neuropsychiatric Adverse Events of Montelukast: An Analysis of Real-World Datasets and drug−gene Interaction Network</td>
+    <td>Frontiers in pharmacology. 2021 Dec 20;12:764279.</td>
+    <td>34987393</td>
+    <td>doi: 10.3389/fphar.2021.764279
+</td>
+</tr>
+<tr>
+    <td>67</td>
+    <td>松尾 俊彦</td>
+    <td>Toshihiko Matsuo </td>
+    <td>Whole Exome-Sequencing of Pooled Genomic DNA Samples to Detect Quantitative Trait Loci in Esotropia and Exotropia of Strabismus in Japanese</td>
+    <td>Life (Basel, Switzerland). 2021 Dec 27;12(1):41.</td>
+    <td>35054434</td>
+    <td>doi: 10.3390/life12010041
+</td>
+</tr>
+<tr>
+    <td>68</td>
+    <td>花野 滋</td>
+    <td>Shigeru Hanano</td>
+    <td>Development of the Binary Vector pTACAtg1 for Stable Gene Expression in Plant; Reduction of Gene Silencing in Transgenic Plants Carrying the Target Gene with Long Flanking Sequences</td>
+    <td>Plant biotechnology (Tokyo, Japan). 2021 Dec 25;38(4):391-400.</td>
+    <td>35087303</td>
+    <td>doi: 10.5511/plantbiotechnology.21.0823a
+</td>
+</tr>
+<tr>
+    <td>69</td>
+    <td>田崎 啓介</td>
+    <td>Keisuke Tasaki</td>
+    <td>Identification and characterization of xanthone biosynthetic genes contributing to the vivid red coloration of red-flowered gentian</td>
+    <td>The Plant journal : for cell and molecular biology. 2021 Sep;107(6):1711-1723.</td>
+    <td>34245606</td>
+    <td>doi: 10.1111/tpj.15412
+</td>
+</tr>
+<tr>
+    <td>70</td>
+    <td>長﨑 正朗</td>
+    <td>Masao Nagasaki</td>
+    <td>Practical guide for managing large-scale human genome data in research</td>
+    <td>Journal of human genetics. 2021 Jan;66(1):39-52.</td>
+    <td>33097812</td>
+    <td>doi: 10.1038/s10038-020-00862-1
+</td>
+</tr>
+<tr>
+    <td>71</td>
+    <td>丹野 広貴</td>
+    <td>Hiroki Tanno</td>
+    <td>Characterization of fructooligosaccharide metabolism and fructooligosaccharide-degrading enzymes in human commensal butyrate producers</td>
+    <td>Gut microbes. 2021 Jan-Dec;13(1):1-20.</td>
+    <td>33439065</td>
+    <td>doi: 10.1080/19490976.2020.1869503
+</td>
+</tr>
+<tr>
+    <td>72</td>
+    <td>河合 洋介</td>
+    <td>Yosuke Kawai</td>
+    <td>Genome-wide SNP data of Izumo and Makurazaki populations support inner-dual structure model for origin of Yamato people</td>
+    <td>Journal of human genetics. 2021 Jul;66(7):681-687.</td>
+    <td>33495571</td>
+    <td>doi: 10.1038/s10038-020-00898-3
+</td>
+</tr>
+<tr>
+    <td>73</td>
+    <td>堀江 真行</td>
+    <td>Masayuki Horie</td>
+    <td>Identification of novel avian and mammalian deltaviruses provides new insights into deltavirus evolution</td>
+    <td>Virus evolution. 2021 Feb 12;7(1):veab003.</td>
+    <td>33614159</td>
+    <td>doi: 10.1093/ve/veab003
+</td>
+</tr>
+<tr>
+    <td>74</td>
+    <td>和智 仲是</td>
+    <td>Nakatada Wachi</td>
+    <td>Genomic population structure of sympatric sexual and asexual populations in a parasitic wasp, Meteorus pulchricornis (Hymenoptera: Braconidae), inferred from six hundred single-nucleotide polymorphism loci</td>
+    <td>Molecular ecology. 2021 Apr;30(7):1612-1623.</td>
+    <td>33634920</td>
+    <td>doi: 10.1111/mec.15834
+</td>
+</tr>
+<tr>
+    <td>75</td>
+    <td>西田 奈央</td>
+    <td>Nao Nishida</td>
+    <td>Importance of HBsAg recognition by HLA molecules as revealed by responsiveness to different hepatitis B vaccines</td>
+    <td>Scientific reports. 2021 Mar 2;11(1):3703.</td>
+    <td>33654122</td>
+    <td>doi: 10.1038/s41598-021-82986-8
+</td>
+</tr>
+<tr>
+    <td>76</td>
+    <td>谷澤 靖洋, 津田 勝利, 中村 保一</td>
+    <td>Yasuhiro Tanizawa, Katsutoshi Tsuda, Yasukazu Nakamura</td>
+    <td>OryzaGenome2.1: Database of Diverse Genotypes in Wild Oryza Species</td>
+    <td>Rice (New York, N.Y.). 2021 Mar 4;14(1):24.</td>
+    <td>33661371</td>
+    <td>doi: 10.1186/s12284-021-00468-x
+</td>
+</tr>
+<tr>
+    <td>77</td>
+    <td>竹崎 直子</td>
+    <td>Naoko Takezaki</td>
+    <td>Resolving the Early Divergence Pattern of Teleost Fish Using Genome-Scale Data</td>
+    <td>Genome biology and evolution. 2021 May 7;13(5):evab052.</td>
+    <td>33739405</td>
+    <td>doi: 10.1093/gbe/evab052
+</td>
+</tr>
+<tr>
+    <td>78</td>
+    <td>川久保 修佑</td>
+    <td>Shusuke Kawakubo</td>
+    <td>Genomic analysis of the brassica pathogen turnip mosaic potyvirus reveals its spread along the former trade routes of the Silk Road</td>
+    <td>Proceedings of the National Academy of Sciences of the United States of America. 2021 Mar 23;118(12):e2021221118.</td>
+    <td>33741737</td>
+    <td>doi: 10.1073/pnas.2021221118
+</td>
+</tr>
+<tr>
+    <td>79</td>
+    <td>殿崎 薫</td>
+    <td>Kaoru Tonosaki</td>
+    <td>Mutation of the imprinted gene OsEMF2a induces autonomous endosperm development and delayed cellularization in rice</td>
+    <td>The Plant cell. 2021 Mar 22;33(1):85-103.</td>
+    <td>33751094</td>
+    <td>doi: 10.1093/plcell/koaa006
+</td>
+</tr>
+<tr>
+    <td>80</td>
+    <td>松尾 芳隆</td>
+    <td>Yoshitaka Matsuo</td>
+    <td>The ribosome collision sensor Hel2 functions as preventive quality control in the secretory pathway</td>
+    <td>Cell reports. 2021 Mar 23;34(12):108877.</td>
+    <td>33761353</td>
+    <td>doi: 10.1016/j.celrep.2021.108877
+</td>
+</tr>
+<tr>
+    <td>81</td>
+    <td>矢原 耕史</td>
+    <td>Koji Yahara</td>
+    <td>Emergence and evolution of antimicrobial resistance genes and mutations in Neisseria gonorrhoeae</td>
+    <td>Genome medicine. 2021 Mar 30;13(1):51.</td>
+    <td>33785063</td>
+    <td>doi: 10.1186/s13073-021-00860-8
+</td>
+</tr>
+<tr>
+    <td>82</td>
+    <td>吉武 和敏</td>
+    <td>Kazutoshi Yoshitake </td>
+    <td>Estimation of tuna population by the improved analytical pipeline of unique molecular identifier-assisted HaCeD-Seq (haplotype count from eDNA)</td>
+    <td>Scientific reports. 2021 Apr 12;11(1):7031.</td>
+    <td>33846364</td>
+    <td>doi: 10.1038/s41598-021-86190-6
+</td>
+</tr>
+<tr>
+    <td>83</td>
+    <td>西井 かなえ</td>
+    <td>Kanae Nishii</td>
+    <td>Mix and match: Patchwork domain evolution of the land plant-specific Ca2+-permeable mechanosensitive channel MCA</td>
+    <td>PloS one. 2021 Apr 15;16(4):e0249735.</td>
+    <td>33857196</td>
+    <td>doi: 10.1371/journal.pone.0249735
+</td>
+</tr>
+<tr>
+    <td>84</td>
+    <td>前野 慎太朗, 遠藤 明仁, 中条 聡</td>
+    <td>Shintaro Maeno, Akihito Endo</td>
+    <td>Niche-specific adaptation of Lactobacillus helveticus strains isolated from malt whisky and dairy fermentations</td>
+    <td>Microbial genomics. 2021 Apr;7(4):000560.</td>
+    <td>33900907</td>
+    <td>doi: 10.1099/mgen.0.000560
+</td>
+</tr>
+<tr>
+    <td>85</td>
+    <td>加藤 有己</td>
+    <td>Yuki Kato</td>
+    <td>RNA editing at a limited number of sites is sufficient to prevent MDA5 activation in the mouse brain</td>
+    <td>PLoS genetics. 2021 May 13;17(5):e1009516.</td>
+    <td>33983932</td>
+    <td>doi: 10.1371/journal.pgen.1009516
+</td>
+</tr>
+<tr>
+    <td>86</td>
+    <td>坊農 秀雅</td>
+    <td>Hidemasa Bono</td>
+    <td>De novo transcriptome analysis for examination of the nutrition metabolic system related to the evolutionary process through which stick insects gain the ability of flight (Phasmatodea).</td>
+    <td>BMC research notes. 2021 May 13;14(1):182.</td>
+    <td>33985569</td>
+    <td>doi: 10.1186/s13104-021-05600-0
+</td>
+</tr>
+<tr>
+    <td>87</td>
+    <td>川崎 純菜, 堀江 真行</td>
+    <td>Junna Kawasaki, Masayuki Horie</td>
+    <td>100-My history of bornavirus infections hidden in vertebrate genomes</td>
+    <td>Proceedings of the National Academy of Sciences of the United States of America. 2021 May 18;118(20):e2026235118.</td>
+    <td>33990470</td>
+    <td>doi: 10.1073/pnas.2026235118
+</td>
+</tr>
+<tr>
+    <td>88</td>
+    <td>本道 栄一</td>
+    <td>Eiichi Hondo</td>
+    <td>Viral-derived DNA invasion and individual variation in an Indonesian population of large flying fox Pteropus vampyrus</td>
+    <td>The Journal of veterinary medical science. 2021 Jul 2;83(7):1068-1074.</td>
+    <td>33994419</td>
+    <td>doi: 10.1292/jvms.21-0115
+</td>
+</tr>
+<tr>
+    <td>89</td>
+    <td>花田 耕介</td>
+    <td>Kousuke Hanada</td>
+    <td>Positive selective sweeps of epigenetic mutations regulating specialized metabolites in plants</td>
+    <td>Genome research. 2021 Jun;31(6):1060-1068.</td>
+    <td>34006571</td>
+    <td>doi: 10.1101/gr.271726.120
+</td>
+</tr>
+<tr>
+    <td>90</td>
+    <td>水口 洋平, 豊田 敦</td>
+    <td>Yohei Minakuchi, Atsushi Toyoda</td>
+    <td>Three genomes in the algal genus Volvox reveal the fate of a haploid sex-determining region after a transition to homothallism</td>
+    <td>Proceedings of the National Academy of Sciences of the United States of America. 2021 May 25;118(21):e2100712118.</td>
+    <td>34011609</td>
+    <td>doi: 10.1073/pnas.2100712118
+</td>
+</tr>
+<tr>
+    <td>91</td>
+    <td>石神 宥真</td>
+    <td>Yuma Ishigami</td>
+    <td>A single m6A modification in U6 snRNA diversifies exon sequence at the 5' splice site</td>
+    <td>Nature communications. 2021 May 28;12(1):3244.</td>
+    <td>34050143</td>
+    <td>doi: 10.1038/s41467-021-23457-6
+</td>
+</tr>
+<tr>
+    <td>92</td>
+    <td>中川 草</td>
+    <td>So Nakagawa</td>
+    <td>SARS-CoV-2 spike L452R variant evades cellular immunity and increases infectivity</td>
+    <td>Cell host &amp; microbe. 2021 Jul 14;29(7):1124-1136.e11.</td>
+    <td>34171266</td>
+    <td>doi: 10.1016/j.chom.2021.06.006
+</td>
+</tr>
+<tr>
+    <td>93</td>
+    <td>岩切 淳一</td>
+    <td>Junichi Iwakiri</td>
+    <td>m6A modification of HSATIII lncRNAs regulates temperature-dependent splicing</td>
+    <td>The EMBO journal. 2021 Aug 2;40(15):e107976.</td>
+    <td>34184765</td>
+    <td>doi: 10.15252/embj.2021107976
+</td>
+</tr>
+<tr>
+    <td>94</td>
+    <td>平野 雅規</td>
+    <td>Masaki Hirano</td>
+    <td>Newly established patient-derived organoid model of intracranial meningioma</td>
+    <td>Neuro-oncology. 2021 Nov 2;23(11):1936-1948.</td>
+    <td>34214169</td>
+    <td>doi: 10.1093/neuonc/noab155
+</td>
+</tr>
+<tr>
+    <td>95</td>
+    <td>市原 知哉, 松本 有樹修</td>
+    <td>Kazuya Ichihara, Akinobu Matsumoto</td>
+    <td>Combinatorial analysis of translation dynamics reveals eIF2 dependence of translation initiation at near-cognate codons</td>
+    <td>Nucleic acids research. 2021 Jul 21;49(13):7298-7317.</td>
+    <td>34226921</td>
+    <td>doi: 10.1093/nar/gkab549
+</td>
+</tr>
+<tr>
+    <td>96</td>
+    <td>榎本 拓央</td>
+    <td>Takuo Enomoto</td>
+    <td>Differences in mineral accumulation and gene expression profiles between two metal hyperaccumulators, Noccaea japonica and Noccaea caerulescens ecotype Ganges, under excess nickel condition</td>
+    <td>Plant signaling &amp; behavior. 2021 Oct 3;16(10):1945212.</td>
+    <td>34227899</td>
+    <td>doi: 10.1080/15592324.2021.1945212
+</td>
+</tr>
+<tr>
+    <td>97</td>
+    <td>小野口 真広</td>
+    <td>Masahiro Onoguchi</td>
+    <td>Binding patterns of RNA-binding proteins to repeat-derived RNA sequences reveal putative functional RNA elements</td>
+    <td>NAR genomics and bioinformatics. 2021 Jul 2;3(3):lqab055.</td>
+    <td>34235430</td>
+    <td>doi: 10.1093/nargab/lqab055
+</td>
+</tr>
+<tr>
+    <td>98</td>
+    <td>原 雄一郎, 國枝 武和</td>
+    <td>Yuichiro Hara, Takekazu Kunieda</td>
+    <td>Parallel evolution of trehalose production machinery in anhydrobiotic animals via recurrent gene loss and horizontal transfer</td>
+    <td>Open biology. 2021 Jul;11(7):200413.</td>
+    <td>34255978</td>
+    <td>doi: 10.1098/rsob.200413
+</td>
+</tr>
+<tr>
+    <td>99</td>
+    <td>草間 和哉</td>
+    <td>Kazuya Kusama</td>
+    <td>Day 7 Embryos Change the Proteomics and Exosomal Micro-RNAs Content of Bovine Uterine Fluid: Involvement of Innate Immune Functions</td>
+    <td>Frontiers in genetics. 2021 Jun 28;12:676791.</td>
+    <td>34262596</td>
+    <td>doi: 10.3389/fgene.2021.676791
+</td>
+</tr>
+<tr>
+    <td>100</td>
+    <td>遠野 雅徳</td>
+    <td>Masanori Tohno</td>
+    <td>Lactobacillus corticis sp. nov., isolated from hardwood bark</td>
+    <td>International journal of systematic and evolutionary microbiology. 2021 Jul;71(7).</td>
+    <td>34264810</td>
+    <td>doi: 10.1099/ijsem.0.004882
+</td>
+</tr>
+<tr>
+    <td>101</td>
+    <td>岩上 哲史</td>
+    <td>Satoshi Iwakami</td>
+    <td>Gene expression shapes the patterns of parallel evolution of herbicide resistance in the agricultural weed Monochoria vaginalis</td>
+    <td>The New phytologist. 2021 Oct;232(2):928-940.</td>
+    <td>34270808</td>
+    <td>doi: 10.1111/nph.17624
+</td>
+</tr>
+<tr>
+    <td>102</td>
+    <td>堀江 真行</td>
+    <td>Masayuki Horie</td>
+    <td>Identification of a novel filovirus in a common lancehead (Bothrops atrox (Linnaeus, 1758))</td>
+    <td>The Journal of veterinary medical science. 2021 Sep 27;83(9):1485-1488.</td>
+    <td>34275961</td>
+    <td>doi: 10.1292/jvms.21-0285
+</td>
+</tr>
+<tr>
+    <td>103</td>
+    <td>大野 翔</td>
+    <td>Sho Ohno</td>
+    <td>Post-transcriptional gene silencing of CYP76AD controls betalain biosynthesis in bracts of bougainvillea</td>
+    <td>Journal of experimental botany. 2021 Oct 26;72(20):6949-6962.</td>
+    <td>34279632</td>
+    <td>doi: 10.1093/jxb/erab340
+</td>
+</tr>
+<tr>
+    <td>104</td>
+    <td>田中 義行</td>
+    <td>Yoshiyuki Tanaka</td>
+    <td>Capsaicinoid biosynthesis in the pericarp of chili pepper fruits is associated with a placental septum‐like transcriptome profile and tissue structure</td>
+    <td>Plant cell reports. 2021 Oct;40(10):1859-1874.</td>
+    <td>34283265</td>
+    <td>doi: 10.1007/s00299-021-02750-0
+</td>
+</tr>
+<tr>
+    <td>105</td>
+    <td>太田 亮作</td>
+    <td>Ryosaku Ota</td>
+    <td>Prediction of HIV drug resistance based on the 3D protein structure: Proposal of molecular field mapping</td>
+    <td>PloS one. 2021 Aug 4;16(8):e0255693.</td>
+    <td>34347839</td>
+    <td>doi: 10.1371/journal.pone.0255693
+</td>
+</tr>
+<tr>
+    <td>106</td>
+    <td>仁田 暁大, 市原 知哉</td>
+    <td>Akihiro Nita, Kazuya Ichihara,</td>
+    <td>A ubiquitin-like protein encoded by the "noncoding" RNA TINCR promotes keratinocyte proliferation and wound healing</td>
+    <td>PLoS genetics. 2021 Aug 5;17(8):e1009686.</td>
+    <td>34351912</td>
+    <td>doi: 10.1371/journal.pgen.1009686
+</td>
+</tr>
+<tr>
+    <td>107</td>
+    <td>瀬川 天太, 高木 宏樹</td>
+    <td>Tenta Segawa, Hiroki Takagi</td>
+    <td>Sat-BSA: an NGS-based method using local de novo assembly of long reads for rapid identification of genomic structural variations associated with agronomic traits</td>
+    <td>Breeding science. 2021 Jun;71(3):299-312.</td>
+    <td>34776737</td>
+    <td>doi: 10.1270/jsbbs.20148
+</td>
+</tr>
+<tr>
+    <td>108</td>
+    <td>矢原 耕史</td>
+    <td>Koji Yahara</td>
+    <td>Long-read metagenomics using PromethION uncovers oral bacteriophages and their interaction with host bacteria</td>
+    <td>Nature communications. 2021 Jan 4;12(1):27.</td>
+    <td>33397904</td>
+    <td>doi: 10.1038/s41467-020-20199-9
+</td>
+</tr>
+<tr>
+    <td>109</td>
+    <td>本道 栄一</td>
+    <td>Eiichi Hondo</td>
+    <td>Dispersal history of Miniopterus fuliginosus bats and their associated viruses in east Asia</td>
+    <td>PloS one. 2021 Jan 14;16(1):e0244006.</td>
+    <td>33444317</td>
+    <td>doi: 10.1371/journal.pone.0244006
+</td>
+</tr>
+<tr>
+    <td>110</td>
+    <td>岸田 拓士, 郷 康広</td>
+    <td>Takushi Kishida, Yasuhiro Go</td>
+    <td>Population history and genomic admixture of sea snakes of the genus Laticauda in the West Pacific</td>
+    <td>Molecular phylogenetics and evolution. 2021 Feb;155:107005.</td>
+    <td>33160037</td>
+    <td>doi: 10.1016/j.ympev.2020.107005
+</td>
+</tr>
+<tr>
+    <td>111</td>
+    <td>前野 慎太朗, 遠藤 明仁</td>
+    <td>Shintaro Maeno, Akihito Endo</td>
+    <td>Unique niche-specific adaptation of fructophilic lactic acid bacteria and proposal of three Apilactobacillus species as novel members of the group</td>
+    <td>BMC microbiology. 2021 Feb 9;21(1):41.</td>
+    <td>33563209</td>
+    <td>doi: 10.1186/s12866-021-02101-9
+</td>
+</tr>
+<tr>
+    <td>112</td>
+    <td>鈴木 郁夫</td>
+    <td>Ikuo K Suzuki</td>
+    <td>Spatial and temporal diversity of DCLK1 isoforms in developing mouse brain</td>
+    <td>Neuroscience research. 2021 Sep;170:154-165.</td>
+    <td>33485913</td>
+    <td>doi: 10.1016/j.neures.2020.12.004
+</td>
+</tr>
+<tr>
+    <td>113</td>
+    <td>堀江 真行</td>
+    <td>Masayuki Horie</td>
+    <td>Identification of a reptile lyssavirus in Anolis allogus provided novel insights into lyssavirus evolution</td>
+    <td>Virus genes. 2021 Feb;57(1):40-49.</td>
+    <td>33159637</td>
+    <td>doi: 10.1007/s11262-020-01803-y
+</td>
+</tr>
+<tr>
+    <td>114</td>
+    <td>西井 かなえ</td>
+    <td>Kanae Nishii</td>
+    <td>Phylogenomics of Gesneriaceae using targeted capture of nuclear genes</td>
+    <td>Molecular phylogenetics and evolution. 2021 Apr;157:107068.</td>
+    <td>33422648</td>
+    <td>doi: 10.1016/j.ympev.2021.107068
+</td>
+</tr>
+<tr>
+    <td>115</td>
+    <td>曽 超</td>
+    <td>Chao Zeng</td>
+    <td>Association analysis of repetitive elements and R-loop formation across species</td>
+    <td>Mobile DNA. 2021 Jan 20;12(1):3.</td>
+    <td>33472695</td>
+    <td>doi: 10.1186/s13100-021-00231-5
+</td>
+</tr>
+<tr>
+    <td>116</td>
+    <td>Rai Amit, ライ メガ, 高橋 弘喜</td>
+    <td>Amit Rai, Megha Rai, Hiroki Takahashi</td>
+    <td>Chromosome-level genome assembly of Ophiorrhiza pumila reveals the evolution of camptothecin biosynthesis</td>
+    <td>Nature communications. 2021 Jan 15;12(1):405.</td>
+    <td>33452249</td>
+    <td>doi: 10.1038/s41467-020-20508-2
+</td>
+</tr>
+<tr>
+    <td>117</td>
+    <td>三橋 里美</td>
+    <td>Satomi Mitsuhashi</td>
+    <td>Genome-wide survey of tandem repeats by nanopore sequencing shows that disease-associated repeats are more polymorphic in the general population</td>
+    <td>BMC medical genomics. 2021 Jan 7;14(1):17.</td>
+    <td>33413375</td>
+    <td>doi: 10.1186/s12920-020-00853-3
+</td>
+</tr>
+<tr>
+    <td>118</td>
+    <td>有泉 亨</td>
+    <td>Tohru Ariizumi</td>
+    <td>De novo genome assembly of two tomato ancestors, Solanum pimpinellifolium and Solanum lycopersicum var. cerasiforme, by long-read sequencing</td>
+    <td>DNA research : an international journal for rapid publication of reports on genes and genomes. 2021 Jan 19;28(1):dsaa029.</td>
+    <td>33475141</td>
+    <td>doi: 10.1093/dnares/dsaa029
+</td>
+</tr>
+<tr>
+    <td>119</td>
+    <td>水口 洋平, 豊田 敦</td>
+    <td>Yohei Minakuchi, Atsushi Toyoda</td>
+    <td>Comparative analysis using the draft genome sequence of California poppy (Eschscholzia californica) for exploring the candidate genes involved in benzylisoquinoline alkaloid biosynthesis</td>
+    <td>Bioscience, biotechnology, and biochemistry. 2021 Mar 24;85(4):851-859.</td>
+    <td>33589920</td>
+    <td>doi: 10.1093/bbb/zbaa091
+</td>
+</tr>
+<tr>
+    <td>120</td>
+    <td>大泉 祐介</td>
+    <td>Yusuke Oizumi</td>
+    <td>Complete sequences of Schizosaccharomyces pombe subtelomeres reveal multiple patterns of genome variation</td>
+    <td>Nature communications. 2021 Jan 27;12(1):611.</td>
+    <td>33504776</td>
+    <td>doi: 10.1038/s41467-020-20595-1
+</td>
+</tr>
+<tr>
+    <td>121</td>
+    <td>小野口 玲菜, 秋光 信佳</td>
+    <td>Rena Onoguchi-Mizutani, Nobuyoshi Akimitsu</td>
+    <td>Identification of novel heat shock-induced long noncoding RNA in human cells</td>
+    <td>Journal of biochemistry. 2021 Apr 29;169(4):497-505.</td>
+    <td>33170212</td>
+    <td>doi: 10.1093/jb/mvaa126
+</td>
+</tr>
+<tr>
+    <td>122</td>
+    <td>渡部 裕介, 大橋 順</td>
+    <td>Yusuke Watanabe, Jun Ohashi</td>
+    <td>Prefecture-level population structure of the Japanese based on SNP genotypes of 11,069 individuals</td>
+    <td>Journal of human genetics. 2021 Apr;66(4):431-437.</td>
+    <td>33051579</td>
+    <td>doi: 10.1038/s10038-020-00847-0
+</td>
+</tr>
+<tr>
+    <td>123</td>
+    <td>小野 幸輝</td>
+    <td>Yukiteru Ono</td>
+    <td>PBSIM2: a simulator for long-read sequencers with a novel generative model of quality scores</td>
+    <td>Bioinformatics (Oxford, England). 2021 May 5;37(5):589-595.</td>
+    <td>32976553</td>
+    <td>doi: 10.1093/bioinformatics/btaa835
+</td>
+</tr>
+<tr>
+    <td>124</td>
+    <td>押木 守</td>
+    <td>Mamoru Oshiki</td>
+    <td>Draft genome sequence of Cytophagales sp. strain WSM2-2, isolated from garden soil</td>
+    <td>Microbiology resource announcements. 2021 Jan 14;10(2):e01238-20.</td>
+    <td>33446590</td>
+    <td>doi: 10.1128/MRA.01238-20
+</td>
+</tr>
+<tr>
+    <td>125</td>
+    <td>西村 瑠佳</td>
+    <td>Luca Nishimura</td>
+    <td>Identification of ancient viruses from metagenomic data of the Jomon people</td>
+    <td>Journal of human genetics. 2021 Mar;66(3):287-296.</td>
+    <td>32994538</td>
+    <td>doi: 10.1038/s10038-020-00841-6
+</td>
+</tr>
+<tr>
+    <td>126</td>
+    <td>宮路 直実</td>
+    <td>Naomi Miyaji</td>
+    <td>The transcriptional response to salicylic acid plays a role in Fusarium yellows resistance in Brassica rapa L</td>
+    <td>Plant cell reports. 2021 Apr;40(4):605-619.</td>
+    <td>33459838</td>
+    <td>doi: 10.1007/s00299-020-02658-1
+</td>
+</tr>
+<tr>
+    <td>127</td>
+    <td>金森 駿介, 河田 雅圭</td>
+    <td>Shunsuke Kanamori, Masakado Kawata</td>
+    <td>Detection of genes positively selected in Cuban Anolis lizards that naturally inhabit hot and open areas, and currently thrive in urban areas</td>
+    <td>Ecology and evolution. 2021 Jan 29;11(4):1719-1728.</td>
+    <td>33613999</td>
+    <td>doi: 10.1002/ece3.7161
+</td>
+</tr>
+<tr>
+    <td>128</td>
+    <td>木村 敦</td>
+    <td>Atsushi P Kimura</td>
+    <td>A dual enhancer-silencer element, DES-K16, in mouse spermatocyte-derived GC-2spd(ts) cells</td>
+    <td>Biochemical and biophysical research communications. 2021 Jan 1;534:1007-1012.</td>
+    <td>33121685</td>
+    <td>doi: 10.1016/j.bbrc.2020.10.049
+</td>
+</tr>
+<tr>
+    <td>129</td>
+    <td>江上 陸, 黒田 真也</td>
+    <td>Riku Egami, Shinya Kuroda</td>
+    <td>Trans-omic analysis reveals obesity-associated dysregulation of inter-organ metabolic cycles between the liver and skeletal muscle</td>
+    <td>iScience. 2021 Feb 20;24(3):102217.</td>
+    <td>33748705</td>
+    <td>doi: 10.1016/j.isci.2021.102217
+</td>
+</tr>
+<tr>
+    <td>130</td>
+    <td>北住 愛</td>
+    <td>Ai Kitazumi</td>
+    <td>Novel and transgressive salinity tolerance in recombinant inbred lines of rice created by physiological coupling-uncoupling and network rewiring effects</td>
+    <td>Frontiers in plant science. 2021 Feb 23;12:615277.</td>
+    <td>33708229</td>
+    <td>doi: 10.3389/fpls.2021.615277
+</td>
+</tr>
+<tr>
+    <td>131</td>
+    <td>平林 茂樹</td>
+    <td>Shigeki Hirabayashi</td>
+    <td>APOBEC3B is preferentially expressed at the G2/M phase of cell cycle</td>
+    <td>Biochemical and biophysical research communications. 2021 Mar 26;546:178-184.</td>
+    <td>33592502</td>
+    <td>doi: 10.1016/j.bbrc.2021.02.008
+</td>
+</tr>
+<tr>
+    <td>132</td>
+    <td>佐藤 健吾</td>
+    <td>Kengo Sato</td>
+    <td>RNA secondary structure prediction using deep learning with thermodynamic integration</td>
+    <td>Nature communications. 2021 Feb 11;12(1):941.</td>
+    <td>33574226</td>
+    <td>doi: 10.1038/s41467-021-21194-4
+</td>
+</tr>
+<tr>
+    <td>133</td>
+    <td>安齋 賢</td>
+    <td>Satoshi Ansai</td>
+    <td>Genome editing reveals fitness effects of a gene for sexual dichromatism in Sulawesian fishes</td>
+    <td>Nature communications. 2021 Mar 1;12(1):1350.</td>
+    <td>33649298</td>
+    <td>doi: 10.1038/s41467-021-21697-0
+</td>
+</tr>
+<tr>
+    <td>134</td>
+    <td>山口 雅也</td>
+    <td>Masaya Yamaguchi</td>
+    <td>Epidemiological analysis of pneumococcal strains isolated at Yangon Children's Hospital in Myanmar via whole-genome sequencing-based methods</td>
+    <td>Microbial genomics. 2021 Feb;7(2):000523.</td>
+    <td>33565958</td>
+    <td>doi: 10.1099/mgen.0.000523
+</td>
+</tr>
+<tr>
+    <td>135</td>
+    <td>井原 邦夫</td>
+    <td>Kunio Ihara</td>
+    <td>Loss of cell wall integrity genes cpxA and mrcB causes flocculation in Escherichia coli</td>
+    <td>The Biochemical journal. 2021 Jan 15;478(1):41-59.</td>
+    <td>33196080</td>
+    <td>doi: 10.1042/BCJ20200723
+</td>
+</tr>
+<tr>
+    <td>136</td>
+    <td>中村 保一</td>
+    <td>Yasukazu Nakamura</td>
+    <td>Complete sequence and structure of the genome of the harmful algal bloom-forming cyanobacterium Planktothrix agardhii NIES-204T and detailed analysis of secondary metabolite gene clusters</td>
+    <td>Harmful algae. 2021 Jan;101:101942.</td>
+    <td>33526179</td>
+    <td>doi: 10.1016/j.hal.2020.101942
+</td>
+</tr>
+<tr>
+    <td>137</td>
+    <td>須崎 大地</td>
+    <td>Daichi Susaki</td>
+    <td>Dynamics of the cell fate specifications during female gametophyte development in Arabidopsis</td>
+    <td>PLoS biology. 2021 Mar 26;19(3):e3001123.</td>
+    <td>33770073</td>
+    <td>doi: 10.1371/journal.pbio.3001123
+</td>
+</tr>
+<tr>
+    <td>138</td>
+    <td>中川 草</td>
+    <td>So Nakagawa</td>
+    <td>Diverse mosquito-specific flaviviruses in the Bolivian Amazon basin</td>
+    <td>The Journal of general virology. 2021 Mar;102(3).</td>
+    <td>33416463</td>
+    <td>doi: 10.1099/jgv.0.001518
+</td>
+</tr>
+<tr>
+    <td>139</td>
+    <td>中川 草</td>
+    <td>So Nakagawa</td>
+    <td>Expression of ERV3-1 in leukocytes of acute myelogenous leukemia patients</td>
+    <td>Gene. 2021 Mar 20;773:145363.</td>
+    <td>33338509</td>
+    <td>doi: 10.1016/j.gene.2020.145363
+</td>
+</tr>
+<tr>
+    <td>140</td>
+    <td>長﨑 正朗</td>
+    <td>Masao Nagasaki</td>
+    <td>Practical guide for managing large-scale human genome data in research</td>
+    <td>Journal of human genetics. 2021 Jan;66(1):39-52.</td>
+    <td>33097812</td>
+    <td>doi: 10.1038/s10038-020-00862-1
+</td>
+</tr>
+<tr>
+    <td>141</td>
+    <td>稲垣 宗一</td>
+    <td>Soichi Inagaki</td>
+    <td>Chromatin-based mechanisms to coordinate convergent overlapping transcription</td>
+    <td>Nature plants. 2021 Mar;7(3):295-302.</td>
+    <td>33649596</td>
+    <td>doi: 10.1038/s41477-021-00868-3
+</td>
+</tr>
+<tr>
+    <td>142</td>
+    <td>吉田 光範</td>
+    <td>Mitsunori Yoshida</td>
+    <td>A Novel DNA Chromatography Method to Discriminate Mycobacterium abscessus Subspecies and Macrolide Susceptibility</td>
+    <td>EBioMedicine. 2021 Feb;64:103187.</td>
+    <td>33446475</td>
+    <td>doi: 10.1016/j.ebiom.2020.103187
+</td>
+</tr>
+<tr>
+    <td>143</td>
+    <td>吉田 光範</td>
+    <td>Mitsunori Yoshida</td>
+    <td>Complete Genome Sequence of Mycobacterium heckeshornense JCM 15655 T, Closely Related to a Pathogenic Nontuberculous Mycobacterial Species, Mycobacterium xenopi</td>
+    <td>Microbiology resource announcements. 2021 Mar 11;10(10):e00020-21.</td>
+    <td>33707319</td>
+    <td>doi: 10.1128/MRA.00020-21
+</td>
+</tr>
+<tr>
+    <td>144</td>
+    <td>千頭 康彦</td>
+    <td>Yasuhiko Chikami</td>
+    <td>Oral RNAi of diap1 results in rapid reduction of damage to potatoes in Henosepilachna vigintioctopunctata</td>
+    <td>Journal of Pest Science volume 94, pages505–515 (2021)</td>
+    <td>NULL</td>
+    <td>doi: 10.1007/s10340-020-01276-w
+</td>
+</tr>
+<tr>
+    <td>145</td>
+    <td>松波 雅俊</td>
+    <td>Masatoshi Matsunami</td>
+    <td>Transcriptomic Changes in Hot Spring Frog Tadpoles (Buergeria otai) in Response to Heat Stress</td>
+    <td>Frontiers in Ecology and Evolution, October 2021, Volume 9, Article 706887, Pages1-9</td>
+    <td>NULL</td>
+    <td>doi: 10.3389/fevo.2021.706887
+</td>
+</tr>
+<tr>
+    <td>146</td>
+    <td>山田 和範, 林 方州</td>
+    <td>Kazunori D YAMADA, Fangzhou LIN</td>
+    <td>Developing a novel recurrent neural network architecture with fewer parameters and good learning performance</td>
+    <td>Interdisciplinary Information Sciences Vol. 27, No. 1 (2021) 25–40</td>
+    <td>NULL</td>
+    <td>doi: 10.4036/iis.2020.R.01
+</td>
+</tr>
+<tr>
+    <td>147</td>
+    <td>安田 仁奈</td>
+    <td>Nina Yasuda</td>
+    <td>Phylogeography of Blue Corals (Genus Heliopora) Across the Indo-West Pacific</td>
+    <td>Frontiers in Marine Science, August 2021, Volume 8, Article 714662</td>
+    <td>NULL</td>
+    <td>doi: 10.3389/fmars.2021.714662
+</td>
+</tr>
+<tr>
+    <td>148</td>
+    <td>佐藤 晋也</td>
+    <td>Shinya Sato</td>
+    <td>Inheritance of spheroid body and plastid in the raphid diatom Epithemia (Bacillariophyta) during sexual reproduction</td>
+    <td>Phycologia, Volume 60, 2021-Issue 3,Pages 265-273</td>
+    <td>NULL</td>
+    <td>doi: 10.1080/00318884.2021.1909399
+</td>
+</tr>
+<tr>
+    <td>149</td>
+    <td>林 方州</td>
+    <td>Fangzhou Lin</td>
+    <td>An Effective Convolutional Neural Network for Visualized Understanding Transboundary Air Pollution Based on Himawari-8 Satellite Images</td>
+    <td>IEEE Geoscience and Remote Sensing Letters ( Volume: 19),13 August 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.1109/LGRS.2021.3102939
+</td>
+</tr>
+<tr>
+    <td>150</td>
+    <td>白石 允梓</td>
+    <td>Masashi Shiraishi</td>
+    <td>Influence of Labor Conditions and Interaction Among Individuals on Circadian Activity Rhythms in the Ant Camponotus Japonicus</td>
+    <td>Journal of Robotics and Mechatronics Vol.33 No.3, 2021, p.582-589</td>
+    <td>NULL</td>
+    <td>doi: 10.20965/jrm.2021.p0582
+</td>
+</tr>
+<tr>
+    <td>151</td>
+    <td>福永 津嵩</td>
+    <td>Tsukasa Fukunaga</td>
+    <td>Mirage: estimation of ancestral gene-copy numbers by considering different evolutionary patterns among gene families</td>
+    <td>Bioinformatics Advances, Volume 1, Issue 1, 2021, 1–10</td>
+    <td>NULL</td>
+    <td>doi: 10.1093/bioadv/vbab014
+</td>
+</tr>
+<tr>
+    <td>152</td>
+    <td>下村 晃一郎</td>
+    <td>Koichiro Shimomura</td>
+    <td>Quantitative trait locus analysis of cucumber fruit texture using double‐digest restriction‐site‐associated DNA sequencing</td>
+    <td>Euphytica volume 217, Article number: 107 (2021)</td>
+    <td>NULL</td>
+    <td>doi: 10.1007/s10681-021-02830-y
+</td>
+</tr>
+<tr>
+    <td>153</td>
+    <td>鳥丸 猛</td>
+    <td>Torimaru Takeshi</td>
+    <td>ヒメアオキの花成関連性遺伝子領域の探索</td>
+    <td>中部森林研究 巻69, p.1-4, 発行日 2021-05-30</td>
+    <td>NULL</td>
+    <td>doi: 10.18999/chufr.69.1
+</td>
+</tr>
+<tr>
+    <td>154</td>
+    <td>鈴木 雅大</td>
+    <td>Masahiro Suzuki</td>
+    <td>A new flattened species of Gracilariopsis (Gracilariales, Rhodophyta) from Japan</td>
+    <td>Phycologia, Volume 60, 2021-Issue 2, 158-163</td>
+    <td>NULL</td>
+    <td>doi: 10.1080/00318884.2021.1880755
+</td>
+</tr>
+<tr>
+    <td>155</td>
+    <td>鈴木 雅大</td>
+    <td>Masahiro Suzuki</td>
+    <td>Morpho-anatomical and molecular reassessments of Rhodymenia prostrata (Rhodymeniaceae, Rhodophyta) from Japan support the recognition of Halopeltis tanakae nom. nov</td>
+    <td>Phycologia, Volume 60, 2021 - Issue 6, Pages 582-588</td>
+    <td>NULL</td>
+    <td>doi: 10.1080/00318884.2021.1959743
+</td>
+</tr>
+<tr>
+    <td>156</td>
+    <td>鈴木 雅大</td>
+    <td>Masahiro Suzuki</td>
+    <td>Fredericqia (Phyllophoraceae, Rhodophyta) in the northwestern Pacific, with the description of Fredericqia chiharae sp. nov.</td>
+    <td>Phycologia, Volume 60, 2021 - Issue 3, Pages 210-214</td>
+    <td>NULL</td>
+    <td>doi: 10.1080/00318884.2021.1892399
+</td>
+</tr>
+<tr>
+    <td>157</td>
+    <td>鈴木 雅大</td>
+    <td>Masahiro Suzuki</td>
+    <td>A new species of the genus Sheathia (Batrachospermaceae, Rhodophyta) from Japan</td>
+    <td>Phycologia, Volume 60, 2021 - Issue 4, Pages 368-374</td>
+    <td>NULL</td>
+    <td>doi: 10.1080/00318884.2021.1946643
+</td>
+</tr>
+<tr>
+    <td>158</td>
+    <td>鈴木 雅大</td>
+    <td>Masahiro Suzuki</td>
+    <td>First record of Sheathia abscondita Stancheva, Sheath & M.L.Vis (Batrachospermaceae, Rhodophyta) from Japan.</td>
+    <td>Bull. Natl. Mus. Nat. Sci., Ser. B, 47(4), pp. 175–182, November 22, 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.50826/bnmnsbot.47.4_175
+</td>
+</tr>
+<tr>
+    <td>159</td>
+    <td>湯山 育子</td>
+    <td>Ikuko Yuyama</td>
+    <td>Application of RNA Interference Technology to Acroporid Juvenile Corals</td>
+    <td>Front. Mar. Sci., 09 August 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.3389/fmars.2021.688876
+</td>
+</tr>
+<tr>
+    <td>160</td>
+    <td>齋藤 裕</td>
+    <td>Yutaka Saito</td>
+    <td>Machine-learning-guided library design cycle for directed evolution of enzymes: the effects of training data composition on sequence space exploration</td>
+    <td>ACS Catal. 2021, 11, 23, 14615–14624</td>
+    <td>NULL</td>
+    <td>doi: 10.1021/acscatal.1c03753
+</td>
+</tr>
+<tr>
+    <td>161</td>
+    <td>佐藤 賢二</td>
+    <td>Kenji Satou</td>
+    <td>Classification of Imbalanced Data Represented as Binary Features</td>
+    <td>Appl. Sci. 2021, 11(17), 7825</td>
+    <td>NULL</td>
+    <td>doi: 10.3390/app11177825
+</td>
+</tr>
+<tr>
+    <td>162</td>
+    <td>下野 嘉子</td>
+    <td>Yoshiko Shimono</td>
+    <td>Revegetation in Japan overlooks geographical genetic structure of native Artemisia indica var. maximowiczii populations</td>
+    <td>Restoration Ecolog 2021</td>
+    <td>NULL</td>
+    <td>doi.org/10.1111/rec.13567
+</td>
+</tr>
+<tr>
+    <td>163</td>
+    <td>神澤 秀明</td>
+    <td>Hideaki Kanzawa-Kiriyama</td>
+    <td>Ancient genomes from the initial Jomon period: new insights into the genetic history of the Japanese archipelago</td>
+    <td>Anthropological Science, Vol. 129(1), 13–22, 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.1537/ase.2012132
+</td>
+</tr>
+<tr>
+    <td>164</td>
+    <td>佐藤 賢二</td>
+    <td>Kenji Satou</td>
+    <td>The Enrichment of Texture Information to Improve Optical Flow for Silhouette Image</td>
+    <td>(IJACSA) International Journal of Advanced Computer Science and Applications, Vol. 12, No. 2, 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.14569/IJACSA.2021.0120253
+</td>
+</tr>
+<tr>
+    <td>165</td>
+    <td>小林 光智衣</td>
+    <td>Michie Kobayashi</td>
+    <td>Insertion of a transposable element in Less Shattering1 (SvLes1) gene is not always involved in foxtail millet (Setaria italica) domestication</td>
+    <td>Genetic Resources and Crop Evolution volume 68, pages 2923–2930 (2021)</td>
+    <td>NULL</td>
+    <td>doi: 10.1007/s10722-021-01165-w
+</td>
+</tr>
+<tr>
+    <td>166</td>
+    <td>坂山 英俊</td>
+    <td>HidetoshiSakayama</td>
+    <td>New distributional records, taxonomy, morphology, and genetic variations of the endangered brackish-water species Lamprothamnium succinctum (Charales, Charophyceae) in Japan</td>
+    <td>Journal of Asia-Pacific Biodiversity, Volume 14, Issue 1, 1 March 2021, Pages 15-22</td>
+    <td>NULL</td>
+    <td>doi: 10.1016/j.japb.2020.09.005
+</td>
+</tr>
+<tr>
+    <td>167</td>
+    <td>毛利 公一, 福永 津嵩</td>
+    <td>Koichi Mori, Tsukasa Fukunaga</td>
+    <td>MotiMul: A significant discriminative sequence motif discovery algorithm with multiple testing correction</td>
+    <td>IEEE, 13 January 2021</td>
+    <td>NULL</td>
+    <td>doi: 10.1109/BIBM49941.2020.9313598</td>
+</tr>
+</table>

--- a/i18n/en/docusaurus-plugin-content-docs/current/report/report.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/report/report.md
@@ -165,51 +165,64 @@ title: "Statistics"
 </table>
 
 
-## 論文数
+## 発行済み査読付き論文数
 
 集計期間：1月1日〜12月31日
-
-※ 原著論文発行済のみを数えることとする
 
 <table>
 <tr>
 	<th width="300">論文雑誌の出版年</th>
-	<th width="300">論文数</th>
+	<th width="300">各年度末更新時に集計した論文数</th>
+	<th width="300">各年度末更新時の後に追加で申請があった論文数</th>
 </tr>
 <tr>
 	<td>2012</td>
 	<td>9</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2013</td>
 	<td>23</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2014</td>
 	<td>53</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2015</td>
 	<td>43</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2016</td>
 	<td>83</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2017</td>
 	<td>93</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2018</td>
 	<td>113</td>
+	<td>0</td>
 </tr>
 <tr>
 	<td>2019</td>
 	<td>104</td>
+	<td>1</td>
 </tr>
 <tr>
 	<td>2020</td>
 	<td>124</td>
+	<td>1</td>
+</tr>
+<tr>
+	<td>2021</td>
+	<td>167</td>
+	<td>0</td>
 </tr>
 </table>

--- a/sidebars.js
+++ b/sidebars.js
@@ -3,9 +3,7 @@
  - create an ordered group of docs
  - render a sidebar for each doc of that group
  - provide next/previous navigation
-
  The sidebars can be generated from the filesystem, or explicitly defined here.
-
  Create as many sidebars as you want.
 */
 
@@ -253,6 +251,7 @@ module.exports = {
                 "operation/operation",
                 "operation/qstatGC",
                 "operation/gfree",
+                "operation/Total_PowerConsumption",
             ]
         }
     ],
@@ -261,6 +260,7 @@ module.exports = {
             "report/report",
         ],
         "論文リスト": [
+            "report/papers_2021",
             "report/papers_2020",
             "report/papers_2019",
             "report/papers_2018",


### PR DESCRIPTION
論文のリストにつきまして、下記4点、作業をいたしました。

１．”Author”→”Supercomputer users in authors list”に修正した
２．2021年分をアップした
３．追加申請分について、「2019.01.01 -- 2019.12.31にユーザによって発表された論文のリスト」の表を、「2019年度の年度末更新時に集計した論文」と、もう1つ新しく「2019年度の年度末更新時に集計した論文」の表を追記した。
４．用語を修正した。
・「20**.01.01 -- 20**.12.31にユーザによって発表された論文リスト」=>「・・・論文のリスト」に修正　https://sc.ddbj.nig.ac.jp/report/papers_2019
・「論文数」=>「発行済み査読付き論文数」に修正し、※の注意書きを削除した。https://sc.ddbj.nig.ac.jp/report/


どうぞよろしくお願いいたします。