### PR TITLE
Edit blog Power_Consumption URL

### DIFF
--- a/blog/2022-09-02-news_PowerConsumption.md
+++ b/blog/2022-09-02-news_PowerConsumption.md
@@ -18,5 +18,5 @@ date: 2022-09-02
 以下のリンクをクリックすると、最近一週間で遺伝研スパコンに使用した電力に関するグラフがリアルタイムで表示されます。
 
 
-- 「&#x1f517;<a href="https://sc2.ddbj.nig.ac.jp/grafana/dashboard/snapshot/nugLTnQVa9KnAbKdrgInlU0MQkVMXqj7?orgId=1&kiosk">遺伝研スパコンの使用電力の状況</a>」
+- 「&#x1f517;<a href="https://sc2.ddbj.nig.ac.jp/grafana/dashboard/snapshot/U6A0L1zFSnyoNHaEAGDwfTNNDKQi4Edj?orgId=1&kiosk">遺伝研スパコンの使用電力の状況</a>」
 

--- a/i18n/en/docusaurus-plugin-content-blog/2022-09-02-news_PowerConsumption.md
+++ b/i18n/en/docusaurus-plugin-content-blog/2022-09-02-news_PowerConsumption.md
@@ -16,4 +16,4 @@ A page about power consumption of the NIG supercomputer has been added to this h
 
 You can see a real-time graph of power consumption of the NIG supercomputer for the past week by clicking the link below.
 
-- 「&#x1f517;<a href="https://sc2.ddbj.nig.ac.jp/grafana/dashboard/snapshot/nugLTnQVa9KnAbKdrgInlU0MQkVMXqj7?orgId=1&kiosk">Power consumption of the NIG supercomputer</a>」
+- 「&#x1f517;<a href="https://sc2.ddbj.nig.ac.jp/grafana/dashboard/snapshot/U6A0L1zFSnyoNHaEAGDwfTNNDKQi4Edj?orgId=1&kiosk">Power consumption of the NIG supercomputer</a>」


### PR DESCRIPTION
「お知らせの「2022 年 9 月 2 日(金) 電力使用状況のページの追加」に記載されている外部リンク「🔗遺伝研スパコンの使用電力の状況」をクリックしても表示されない。」につきまして、URLを修正いたしました。

最新版に差し替えたつもりでしたが、1つ前の版(3つあったグラフを1つだけ表示されるようにしたページ)のURLのままとなっておりました。クリックすると、最新版(縦の単位を”W”に修正したページ)が表示されるようになります。

どうぞよろしくお願いいたします。