### PR TITLE
Fix misplaced external links

### DIFF
--- a/docs/advanced_guides/030_Education/Amelieff.md
+++ b/docs/advanced_guides/030_Education/Amelieff.md
@@ -11,14 +11,13 @@ title: 遺伝研スパコンの活用に役立つアメリエフ株式会社「B
 
 - 過去のPAGS・DDBJ合同情報解析講習会情報（ビデオ・資料）- 先進ゲノム支援事業公式ページ
     - https://www.genome-sci.jp/bioinformatic
-    - https://togotv.dbcls.jp/ajacs_text.html
 
 :::
 
 :::info 他の文科省関連事業
 
 - NBDCデータ解析講習会（AJACS）ビデオ資料 - DBCLS 統合TV
-    - https://www.genome-sci.jp/bioinformatic
+     - https://togotv.dbcls.jp/ajacs_text.html
 
 :::
 


### PR DESCRIPTION
## 概要

Docusaurus特有のマークダウン記法Admonitionに囲まれたinfoごとの外部リンク紐付け対応を修正し、表示不具合を解消しました。

## 変更内容

- :::info 先進ゲノム解析研究推進プラットフォーム(先進ゲノム支援) ＞ 過去のPAGS・DDBJ合同情報解析講習会情報（ビデオ・資料）- 先進ゲノム支援事業公式ページに https://www.genome-sci.jp/bioinformatic を紐付け
- :::info 他の文科省関連事業 ＞ NBDCデータ解析講習会（AJACS）ビデオ資料 - DBCLS 統合TV に https://togotv.dbcls.jp/ajacs_text.html を紐付け