### PR TITLE
Align English documentation with Japanese updates

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/advanced_guides/030_Education/Amelieff.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/advanced_guides/030_Education/Amelieff.md
@@ -23,7 +23,7 @@ Against this backdrop, bioinformatics training workshops are held at various ins
 
 However, participation is sometimes limited, and the demo environment used during a workshop often differs from the actual analysis environment each researcher uses in their own work. Participants also vary widely in skill level, making it difficult to provide individualized support.
 
-With these challenges in mind, under the collaboration of Dr. Osamu Ogasawara, Head of the DDBJ Systems Administration Division at NIG and a research support collaborator for the PAGS project (NIG hub), efforts are ongoing to improve the analysis environment on the NIG Supercomputer and to enhance the information available to users. In parallel, we are progressively compiling information resources from organizations with relevant expertise — resources that are accessible to beginners and useful to PAGS and NIG Supercomputer users alike.
+With these challenges in mind, we are working to improve the analysis environment on the NIG Supercomputer and to enhance user-facing information. In parallel, we are gradually compiling information resources from organizations with relevant expertise, focusing on resources that are accessible to beginners and useful to both PAGS and NIG Supercomputer users.
 
 Last year, we introduced convenient tools from academic sources. This year, as a new example of a company supporting academic research, we introduce Amelieff Inc.
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/advanced_guides/030_Education/Amelieff.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/advanced_guides/030_Education/Amelieff.md
@@ -9,10 +9,16 @@ Against this backdrop, bioinformatics training workshops are held at various ins
 
 :::info Advanced Genome Support Project (PAGS)
 
-- Past workshop materials (videos and slides) — PAGS official website
+- Past PAGS–DDBJ Joint Bioinformatics Training Courses: Videos and Materials — Official Website of the Advanced Genome Support Program
     - https://www.genome-sci.jp/bioinformatic
-- [Related] NBDC Data Analysis Workshop (AJACS) video materials — DBCLS Togo TV
+
+:::
+
+:::info Other MEXT-related programs
+
+- NBDC Data Analysis Workshop (AJACS) video materials — DBCLS Togo TV
     - https://togotv.dbcls.jp/ajacs_text.html
+
 :::
 
 However, participation is sometimes limited, and the demo environment used during a workshop often differs from the actual analysis environment each researcher uses in their own work. Participants also vary widely in skill level, making it difficult to provide individualized support.


### PR DESCRIPTION
## 概要

日本語版の変更箇所に合わせて該当箇所を修正しました。

## 変更内容

- 導入説明文の表現を調整（不要な文言を削除と削除に伴う表現の調整）
- バイオインフォマティクス講習動画リンクの構成表示変更
:::info Other MEXT-related programs のタグの追加
- 過去のゲノム支援講習会情報に「PAGS・DDBJ合同」を明記